### PR TITLE
Fusesoc nexys a7

### DIFF
--- a/fpga/clk_gen_bypass.vhd
+++ b/fpga/clk_gen_bypass.vhd
@@ -1,0 +1,20 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity clock_generator is
+  port (
+    clk        : in  std_logic;
+    resetn     : in  std_logic;
+    system_clk : out std_logic;
+    locked     : out std_logic);
+
+end entity clock_generator;
+
+architecture bypass of clock_generator is
+
+begin
+
+  locked <= not resetn;
+  system_clk <= clk;
+
+end architecture bypass;

--- a/fpga/nexys_a7.xdc
+++ b/fpga/nexys_a7.xdc
@@ -1,0 +1,7 @@
+set_property -dict {PACKAGE_PIN E3 IOSTANDARD LVCMOS33} [get_ports clk]
+create_clock -period 10.000 -name sys_clk_pin -waveform {0.000 5.000} -add [get_ports clk]
+
+set_property -dict {PACKAGE_PIN C12 IOSTANDARD LVCMOS33} [get_ports reset_n]
+
+set_property -dict {PACKAGE_PIN D4 IOSTANDARD LVCMOS33} [get_ports uart0_txd]
+set_property -dict {PACKAGE_PIN C4 IOSTANDARD LVCMOS33} [get_ports uart0_rxd]

--- a/fpga/pp_soc_memory.vhd
+++ b/fpga/pp_soc_memory.vhd
@@ -11,7 +11,8 @@ use work.pp_utilities.all;
 --! @brief Simple memory module for use in Wishbone-based systems.
 entity pp_soc_memory is
 	generic(
-		MEMORY_SIZE : natural := 4096 --! Memory size in bytes.
+		MEMORY_SIZE   : natural := 4096; --! Memory size in bytes.
+		RAM_INIT_FILE : string
 	);
 	port(
 		clk : in std_logic;
@@ -48,7 +49,7 @@ architecture behaviour of pp_soc_memory is
         return temp_ram;
     end function;
 
-    signal memory : ram_t := init_ram("firmware.hex");
+    signal memory : ram_t := init_ram(RAM_INIT_FILE);
 
 	attribute ram_style : string;
 	attribute ram_style of memory : signal is "block";

--- a/fpga/toplevel.vhd
+++ b/fpga/toplevel.vhd
@@ -3,13 +3,18 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
+use ieee.math_real.all;
 
 library work;
 use work.wishbone_types.all;
 
+
 -- 0x00000000: Main memory (1 MB)
 -- 0xc0002000: UART0 (for host communication)
 entity toplevel is
+  generic (
+    MEMORY_SIZE   : positive := 1048576;
+    RAM_INIT_FILE : string   := "firmware.hex");
 	port(
 		clk       : in  std_logic;
 		reset_n   : in  std_logic;
@@ -54,7 +59,7 @@ architecture behaviour of toplevel is
 	signal uart0_ack_out : std_logic;
 
 	-- Main memory signals:
-	signal main_memory_adr_in  : std_logic_vector(19 downto 0);
+	signal main_memory_adr_in  : std_logic_vector(positive(ceil(log2(real(MEMORY_SIZE))))-1 downto 0);
 	signal main_memory_dat_in  : std_logic_vector(63 downto 0);
 	signal main_memory_dat_out : std_logic_vector(63 downto 0);
 	signal main_memory_cyc_in  : std_logic;
@@ -190,7 +195,8 @@ begin
 
 	main_memory: entity work.pp_soc_memory
 		generic map(
-			MEMORY_SIZE => 1048576
+			MEMORY_SIZE   => MEMORY_SIZE,
+			RAM_INIT_FILE => RAM_INIT_FILE
 		) port map(
 			clk => system_clk,
 			reset => reset,

--- a/microwatt.core
+++ b/microwatt.core
@@ -66,6 +66,12 @@ targets:
       vivado: {part : xc7a200tsbg484-1}
     toplevel : toplevel
 
+  synth:
+    filesets: [core]
+    tools:
+      vivado: {pnr : none}
+    toplevel: core
+
 parameters:
   memory_size:
     datatype    : int

--- a/microwatt.core
+++ b/microwatt.core
@@ -1,0 +1,65 @@
+CAPI=2:
+
+name : ::microwatt:0
+
+filesets:
+  core:
+    files:
+      - decode_types.vhdl
+      - wishbone_types.vhdl
+      - common.vhdl
+      - fetch1.vhdl
+      - fetch2.vhdl
+      - decode1.vhdl
+      - helpers.vhdl
+      - decode2.vhdl
+      - register_file.vhdl
+      - cr_file.vhdl
+      - crhelpers.vhdl
+      - ppc_fx_insns.vhdl
+      - sim_console.vhdl
+      - execute1.vhdl
+      - execute2.vhdl
+      - loadstore1.vhdl
+      - loadstore2.vhdl
+      - multiply.vhdl
+      - writeback.vhdl
+      - wishbone_arbiter.vhdl
+      - core.vhdl
+    file_type : vhdlSource-2008
+
+  soc:
+    files:
+      - fpga/pp_fifo.vhd
+      - fpga/pp_soc_memory.vhd
+      - fpga/pp_soc_reset.vhd
+      - fpga/pp_soc_uart.vhd
+      - fpga/pp_utilities.vhd
+      - fpga/toplevel.vhd
+      - fpga/firmware.hex : {copyto : firmware.hex, file_type : user}
+    file_type : vhdlSource-2008
+
+  nexys_a7:
+    files:
+      - fpga/nexys_a7.xdc : {file_type : xdc}
+      - fpga/clk_gen_bypass.vhd : {file_type : vhdlSource-2008}
+
+targets:
+  nexys_a7:
+    default_tool: vivado
+    filesets: [core, nexys_a7, soc]
+    parameters : [memory_size, ram_init_file]
+    tools:
+      vivado: {part : xc7a100tcsg324-1}
+    toplevel : toplevel
+
+parameters:
+  memory_size:
+    datatype    : int
+    description : On-chip memory size (bytes)
+    paramtype   : generic
+
+  ram_init_file:
+    datatype    : file
+    description : Initial on-chip RAM contents
+    paramtype   : generic

--- a/microwatt.core
+++ b/microwatt.core
@@ -44,6 +44,11 @@ filesets:
       - fpga/nexys_a7.xdc : {file_type : xdc}
       - fpga/clk_gen_bypass.vhd : {file_type : vhdlSource-2008}
 
+  nexys_video:
+    files:
+      - fpga/nexys-video.xdc : {file_type : xdc}
+      - fpga/clk_gen_bypass.vhd : {file_type : vhdlSource-2008}
+
 targets:
   nexys_a7:
     default_tool: vivado
@@ -51,6 +56,14 @@ targets:
     parameters : [memory_size, ram_init_file]
     tools:
       vivado: {part : xc7a100tcsg324-1}
+    toplevel : toplevel
+
+  nexys_video:
+    default_tool: vivado
+    filesets: [core, nexys_video, soc]
+    parameters : [memory_size, ram_init_file]
+    tools:
+      vivado: {part : xc7a200tsbg484-1}
     toplevel : toplevel
 
 parameters:


### PR DESCRIPTION
Adds support for building microwatt for Nexys A7 with FuseSoC

How to use:

1. Install fusesoc with `pip install fusesoc` or see instructions at https://github.com/olofk/fusesoc
2. Create a workspace directory. All commands will be executed from there
3. Add microwatt as a library with `fusesoc library add microwatt /path/to/microwatt`
4. Run `fusesoc run --target=nexys_a7 microwatt --memory_size=65536` (if memory_size is omitted it will default to 1048576 which is required for the default firmware but too much for nexys a7)

The default firmware can be changed with the `--ram_init_file` parameter (`fusesoc run --target=nexys_a7 microwatt --ram_init_file=path/to/firmware.hex`

Target-specific parameters can be listed with `fusesoc run --target=nexys_a7 microwatt --help`
