### PR TITLE
Fusesoc arty a7

### DIFF
--- a/fpga/arty_a7-35.xdc
+++ b/fpga/arty_a7-35.xdc
@@ -1,0 +1,7 @@
+set_property -dict { PACKAGE_PIN E3    IOSTANDARD LVCMOS33 } [get_ports { clk }];
+create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports { clk }];
+
+set_property -dict { PACKAGE_PIN A8    IOSTANDARD LVCMOS33 } [get_ports { reset_n }]; #mapped to SW0
+
+set_property -dict { PACKAGE_PIN D10   IOSTANDARD LVCMOS33 } [get_ports { uart0_txd }]; 
+set_property -dict { PACKAGE_PIN A9    IOSTANDARD LVCMOS33 } [get_ports { uart0_rxd }];

--- a/microwatt.core
+++ b/microwatt.core
@@ -48,6 +48,12 @@ filesets:
     files:
       - fpga/nexys-video.xdc : {file_type : xdc}
       - fpga/clk_gen_plle2.vhd : {file_type : vhdlSource-2008}
+      
+  arty_a7-35:
+    files:
+      - fpga/arty_a7-35.xdc : {file_type : xdc}
+      - fpga/clk_gen_plle2.vhd : {file_type : vhdlSource-2008}
+  
 
 targets:
   nexys_a7:
@@ -64,6 +70,14 @@ targets:
     parameters : [memory_size, ram_init_file]
     tools:
       vivado: {part : xc7a200tsbg484-1}
+    toplevel : toplevel
+    
+  arty_a7-35:
+    default_tool: vivado
+    filesets: [core, arty_a7-35, soc]
+    parameters : [memory_size, ram_init_file]
+    tools:
+      vivado: {part : xc7a35ticsg324-1L}
     toplevel : toplevel
 
   synth:


### PR DESCRIPTION
I added a target for the Arty A7-35 board, a fairly popular and affordable dev board.
The micropython image does not fit in this board without using DDR3, so when running fusesoc, the --memory_size is needed to select a smaller amount of RAM and --ram_init_file to select a different hex file, for example the hello world one.
The Fusesoc target name is arty_a7. 

For example:
fusesoc run --target=arty_a7-35 microwatt --memory_size=65536 --ram_init_file=hello_world.hex