### PR TITLE
Arty A7 reset pin is C2

### DIFF
--- a/fpga/arty_a7-35.xdc
+++ b/fpga/arty_a7-35.xdc
@@ -1,7 +1,7 @@
 set_property -dict { PACKAGE_PIN E3    IOSTANDARD LVCMOS33 } [get_ports { clk }];
 create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports { clk }];
 
-set_property -dict { PACKAGE_PIN A8    IOSTANDARD LVCMOS33 } [get_ports { reset_n }]; #mapped to SW0
+set_property -dict { PACKAGE_PIN C2    IOSTANDARD LVCMOS33 } [get_ports { reset_n }];
 
-set_property -dict { PACKAGE_PIN D10   IOSTANDARD LVCMOS33 } [get_ports { uart0_txd }]; 
+set_property -dict { PACKAGE_PIN D10   IOSTANDARD LVCMOS33 } [get_ports { uart0_txd }];
 set_property -dict { PACKAGE_PIN A9    IOSTANDARD LVCMOS33 } [get_ports { uart0_rxd }];

--- a/microwatt.core
+++ b/microwatt.core
@@ -48,12 +48,12 @@ filesets:
     files:
       - fpga/nexys-video.xdc : {file_type : xdc}
       - fpga/clk_gen_plle2.vhd : {file_type : vhdlSource-2008}
-      
+
   arty_a7-35:
     files:
       - fpga/arty_a7-35.xdc : {file_type : xdc}
       - fpga/clk_gen_plle2.vhd : {file_type : vhdlSource-2008}
-  
+
 
 targets:
   nexys_a7:
@@ -71,7 +71,7 @@ targets:
     tools:
       vivado: {part : xc7a200tsbg484-1}
     toplevel : toplevel
-    
+
   arty_a7-35:
     default_tool: vivado
     filesets: [core, arty_a7-35, soc]


### PR DESCRIPTION
Use C2 for reset, and fix up a few whitespace issues.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>