### PR TITLE
Cmod A7-35 support

### DIFF
--- a/fpga/clk_gen_mcmm.vhd
+++ b/fpga/clk_gen_mcmm.vhd
@@ -1,0 +1,76 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+Library UNISIM;
+use UNISIM.vcomponents.all;
+
+entity clock_generator is
+    generic (
+        clk_period_hz  : positive := 12000000);
+    port (
+        ext_clk        : in  std_logic;
+        pll_rst_in     : in  std_logic;
+        pll_clk_out    : out std_logic;
+        pll_locked_out : out std_logic);
+end entity clock_generator;
+
+architecture rtl of clock_generator is
+    signal clkfb : std_ulogic;
+
+    type pll_settings_t is record
+        clkin_period  : real range 10.000 to 800.0;
+        clkfbout_mult : real range 2.0 to 64.0;
+        clkout_divide : real range 1.0 to 128.0;
+        divclk_divide : integer range 1 to 106;
+    end record pll_settings_t;
+
+    function gen_pll_settings (
+        constant freq_hz : positive)
+        return pll_settings_t is
+    begin
+        if freq_hz = 100000000 then
+            return (clkin_period  => 10.0,
+                    clkfbout_mult => 16.0,
+                    clkout_divide => 32.0,
+                    divclk_divide => 1);
+        elsif freq_hz = 12000000 then
+            return (clkin_period  => 83.33,
+                    clkfbout_mult => 50.0,
+                    clkout_divide => 12.0,
+                    divclk_divide => 1);
+        else
+            report "Unsupported input frequency" severity failure;
+        end if;
+    end function gen_pll_settings;
+
+    constant pll_settings : pll_settings_t := gen_pll_settings(clk_period_hz);
+begin
+    pll : MMCME2_BASE
+        generic map (
+            BANDWIDTH          => "OPTIMIZED",
+            CLKFBOUT_MULT_F    => pll_settings.clkfbout_mult,
+            CLKIN1_PERIOD      => pll_settings.clkin_period,
+            CLKOUT0_DIVIDE_F   => pll_settings.clkout_divide,
+            DIVCLK_DIVIDE      => pll_settings.divclk_divide,
+            STARTUP_WAIT       => FALSE)
+        port map (
+            CLKFBOUT   => clkfb,
+            CLKFBOUTB  => open,
+            CLKOUT0    => pll_clk_out,
+            CLKOUT0B   => open,
+            CLKOUT1    => open,
+            CLKOUT1B   => open,
+            CLKOUT2    => open,
+            CLKOUT2B   => open,
+            CLKOUT3    => open,
+            CLKOUT3B   => open,
+            CLKOUT4    => open,
+            CLKOUT5    => open,
+            CLKOUT6    => open,
+            LOCKED     => pll_locked_out,
+            CLKFBIN    => clkfb,
+            CLKIN1     => ext_clk,
+            PWRDWN     => '0',
+            RST        => pll_rst_in
+            );
+end architecture rtl;

--- a/fpga/cmod_a7-35.xdc
+++ b/fpga/cmod_a7-35.xdc
@@ -1,0 +1,8 @@
+## Clock signal 12 MHz
+set_property -dict { PACKAGE_PIN L17   IOSTANDARD LVCMOS33 } [get_ports { ext_clk }];
+create_clock -add -name sys_clk_pin -period 83.33 -waveform {0 41.66} [get_ports {ext_clk}];
+
+set_property -dict { PACKAGE_PIN J18   IOSTANDARD LVCMOS33 } [get_ports { uart0_txd }];
+set_property -dict { PACKAGE_PIN J17   IOSTANDARD LVCMOS33 } [get_ports { uart0_rxd  }];
+
+set_property -dict { PACKAGE_PIN A18   IOSTANDARD LVCMOS33 } [get_ports { ext_rst }];

--- a/microwatt.core
+++ b/microwatt.core
@@ -55,6 +55,10 @@ filesets:
       - fpga/arty_a7-35.xdc : {file_type : xdc}
       - fpga/clk_gen_plle2.vhd : {file_type : vhdlSource-2008}
 
+  cmod_a7-35:
+    files:
+      - fpga/cmod_a7-35.xdc : {file_type : xdc}
+      - fpga/clk_gen_mcmm.vhd : {file_type : vhdlSource-2008}
 
 targets:
   nexys_a7:
@@ -81,6 +85,14 @@ targets:
       vivado: {part : xc7a35ticsg324-1L}
     toplevel : toplevel
 
+  cmod_a7-35:
+    default_tool: vivado
+    filesets: [core, cmod_a7-35, soc]
+    parameters : [memory_size, ram_init_file, reset_low=false]
+    tools:
+      vivado: {part : xc7a35tcpg236-1}
+    toplevel : toplevel
+
   synth:
     filesets: [core]
     tools:
@@ -96,4 +108,9 @@ parameters:
   ram_init_file:
     datatype    : file
     description : Initial on-chip RAM contents
+    paramtype   : generic
+
+  reset_low:
+    datatype    : bool
+    description : External reset button polarity
     paramtype   : generic


### PR DESCRIPTION
I need to clean up the reset issues (this patch breaks everyone
else), but this gets the board up and running.

I had to use the MMCM because the clock (12 MHz) is below the PLL
minimum of 19 MHz.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>