### PR TITLE
Add CONFIG_VOLTAGE and CFGBVS entries

### DIFF
--- a/fpga/arty_a7-35.xdc
+++ b/fpga/arty_a7-35.xdc
@@ -5,3 +5,6 @@ set_property -dict { PACKAGE_PIN C2    IOSTANDARD LVCMOS33 } [get_ports { reset_
 
 set_property -dict { PACKAGE_PIN D10   IOSTANDARD LVCMOS33 } [get_ports { uart0_txd }];
 set_property -dict { PACKAGE_PIN A9    IOSTANDARD LVCMOS33 } [get_ports { uart0_rxd }];
+
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+set_property CFGBVS VCCO [current_design]

--- a/fpga/nexys_a7.xdc
+++ b/fpga/nexys_a7.xdc
@@ -5,3 +5,6 @@ set_property -dict {PACKAGE_PIN C12 IOSTANDARD LVCMOS33} [get_ports reset_n]
 
 set_property -dict {PACKAGE_PIN D4 IOSTANDARD LVCMOS33} [get_ports uart0_txd]
 set_property -dict {PACKAGE_PIN C4 IOSTANDARD LVCMOS33} [get_ports uart0_rxd]
+
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+set_property CFGBVS VCCO [current_design]


### PR DESCRIPTION
Remove a couple of warnings from Vivado.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>