### PR TITLE
Clean up register read debug output

### DIFF
--- a/common.vhdl
+++ b/common.vhdl
@@ -67,8 +67,11 @@ package common is
 	constant Decode2ToMultiplyInit : Decode2ToMultiplyType := (valid => '0', insn_type => OP_ILLEGAL, rc => '0', others => (others => '0'));
 
 	type Decode2ToRegisterFileType is record
+		read1_enable : std_ulogic;
 		read1_reg : std_ulogic_vector(4 downto 0);
+		read2_enable : std_ulogic;
 		read2_reg : std_ulogic_vector(4 downto 0);
+		read3_enable : std_ulogic;
 		read3_reg : std_ulogic_vector(4 downto 0);
 	end record;
 

--- a/decode2.vhdl
+++ b/decode2.vhdl
@@ -206,6 +206,10 @@ begin
 		decoded_reg_b := decode_input_reg_b (d.decode.input_reg_b, d.insn, r_in.read2_data);
 		decoded_reg_c := decode_input_reg_c (d.decode.input_reg_c, d.insn, r_in.read3_data);
 
+		r_out.read1_enable <= decoded_reg_a.reg_valid;
+		r_out.read2_enable <= decoded_reg_b.reg_valid;
+		r_out.read3_enable <= decoded_reg_c.reg_valid;
+
 		case d.decode.unit is
 		when ALU =>
 			e_out.valid <= d.valid;

--- a/register_file.vhdl
+++ b/register_file.vhdl
@@ -28,12 +28,12 @@ begin
 		if rising_edge(clk) then
 			if w_in.write_enable = '1' then
 				assert not(is_x(w_in.write_data)) and not(is_x(w_in.write_reg)) severity failure;
-				report "Writing " & to_hstring(w_in.write_data) & " to " & to_hstring(w_in.write_reg);
+				report "Writing GPR " & to_hstring(w_in.write_reg) & " " & to_hstring(w_in.write_data);
 				registers(to_integer(unsigned(w_in.write_reg))) <= w_in.write_data;
 			end if;
 			if w_in.write_enable2 = '1' then
 				assert not(is_x(w_in.write_data2)) and not(is_x(w_in.write_reg2)) severity failure;
-				report "Writing " & to_hstring(w_in.write_data2) & " to " & to_hstring(w_in.write_reg2);
+				report "Writing GPR " & to_hstring(w_in.write_reg2) & " " & to_hstring(w_in.write_data2);
 				registers(to_integer(unsigned(w_in.write_reg2))) <= w_in.write_data2;
 			end if;
 		end if;
@@ -42,9 +42,15 @@ begin
 	-- asynchronous reads
 	register_read_0: process(all)
 	begin
-		report "read " & to_hstring(d_in.read1_reg) & " " & to_hstring(registers(to_integer(unsigned(d_in.read1_reg))));
-		report "read " & to_hstring(d_in.read2_reg) & " " & to_hstring(registers(to_integer(unsigned(d_in.read2_reg))));
-		report "read " & to_hstring(d_in.read3_reg) & " " & to_hstring(registers(to_integer(unsigned(d_in.read3_reg))));
+		if d_in.read1_enable = '1' then
+			report "Reading GPR " & to_hstring(d_in.read1_reg) & " " & to_hstring(registers(to_integer(unsigned(d_in.read1_reg))));
+		end if;
+		if d_in.read2_enable = '1' then
+			report "Reading GPR " & to_hstring(d_in.read2_reg) & " " & to_hstring(registers(to_integer(unsigned(d_in.read2_reg))));
+		end if;
+		if d_in.read3_enable = '1' then
+			report "Reading GPR " & to_hstring(d_in.read3_reg) & " " & to_hstring(registers(to_integer(unsigned(d_in.read3_reg))));
+		end if;
 		d_out.read1_data <= registers(to_integer(unsigned(d_in.read1_reg)));
 		d_out.read2_data <= registers(to_integer(unsigned(d_in.read2_reg)));
 		d_out.read3_data <= registers(to_integer(unsigned(d_in.read3_reg)));


### PR DESCRIPTION
Right now we continually print all 3 possible GPRs an instruction
may be using. Add signals so we only print GPRs when they are
actually read. This should hopefully optimise away when synthesized.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>