### PR TITLE
Fix CR forwarding

### DIFF
--- a/cr_file.vhdl
+++ b/cr_file.vhdl
@@ -55,6 +55,6 @@ begin
 		if d_in.read = '1' then
 			report "Reading CR " & to_hstring(crs_updated);
 		end if;
-		d_out.read_cr_data <= crs;
+		d_out.read_cr_data <= crs_updated;
 	end process;
 end architecture behaviour;


### PR DESCRIPTION
We weren't actually forwarding writes in the same cycle. Not a
problem right now, but noticed when testing the pipelining series.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>