### PR TITLE
Size reduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@
 core_tb
 fetch_tb
 loadstore_tb
+soc_reset_tb
 simple_ram_behavioural_tb
+simple_ram_behavioural.bin

--- a/common.vhdl
+++ b/common.vhdl
@@ -164,7 +164,7 @@ package common is
 		write_cr_mask: std_ulogic_vector(7 downto 0);
 		write_cr_data: std_ulogic_vector(31 downto 0);
 	end record;
-	constant MultiplyToWritebackInit : MultiplyToWritebackType := (valid => '0', write_reg_enable => '0', write_cr_enable => '0', others => (others => '0'));
+	constant MultiplyToWritebackInit : MultiplyToWritebackType := (valid => '0', write_reg_enable => '0', write_cr_enable => '0', others => (others => '-'));
 
 	type WritebackToRegisterFileType is record
 		write_reg : std_ulogic_vector(4 downto 0);

--- a/common.vhdl
+++ b/common.vhdl
@@ -108,7 +108,7 @@ package common is
 		update : std_ulogic;				-- is this an update instruction?
 		update_reg : std_ulogic_vector(4 downto 0);	-- if so, the register to update
 	end record;
-	constant Decode2ToLoadstore1Init : Decode2ToLoadstore1Type := (valid => '0', load => '0', byte_reverse => '0', sign_extend => '0', update => '0', others => (others => '0'));
+	constant Decode2ToLoadstore1Init : Decode2ToLoadstore1Type := (valid => '0', load => '0', byte_reverse => '0', sign_extend => '0', update => '0', others => (others => '-'));
 
 	type Loadstore1ToLoadstore2Type is record
 		valid : std_ulogic;

--- a/common.vhdl
+++ b/common.vhdl
@@ -52,7 +52,7 @@ package common is
 		input_cr: std_ulogic;
 		output_cr: std_ulogic;
 	end record;
-	constant Decode2ToExecute1Init : Decode2ToExecute1Type := (valid => '0', insn_type => OP_ILLEGAL, lr => '0', rc => '0', input_carry => '0', output_carry => '0', input_cr => '0', output_cr => '0', others => (others => '0'));
+	constant Decode2ToExecute1Init : Decode2ToExecute1Type := (valid => '0', insn_type => OP_ILLEGAL, lr => '0', rc => '0', input_carry => '0', output_carry => '0', input_cr => '0', output_cr => '0', others => (others => '-'));
 
 	type Decode2ToMultiplyType is record
 		valid: std_ulogic;

--- a/common.vhdl
+++ b/common.vhdl
@@ -152,7 +152,7 @@ package common is
 		write_cr_mask : std_ulogic_vector(7 downto 0);
 		write_cr_data : std_ulogic_vector(31 downto 0);
 	end record;
-	constant Execute2ToWritebackInit : Execute2ToWritebackType := (valid => '0', write_enable => '0', write_cr_enable => '0', others => (others => '0'));
+	constant Execute2ToWritebackInit : Execute2ToWritebackType := (valid => '0', write_enable => '0', write_cr_enable => '0', others => (others => '-'));
 
 	type MultiplyToWritebackType is record
 		valid: std_ulogic;

--- a/common.vhdl
+++ b/common.vhdl
@@ -92,7 +92,7 @@ package common is
 		redirect: std_ulogic;
 		redirect_nia: std_ulogic_vector(63 downto 0);
 	end record;
-	constant Execute1ToFetch1TypeInit : Execute1ToFetch1Type := (redirect => '0', others => (others => '0'));
+	constant Execute1ToFetch1TypeInit : Execute1ToFetch1Type := (redirect => '0', others => (others => '-'));
 
 	type Decode2ToLoadstore1Type is record
 		valid : std_ulogic;

--- a/common.vhdl
+++ b/common.vhdl
@@ -178,7 +178,7 @@ package common is
 		write_cr_mask : std_ulogic_vector(7 downto 0);
 		write_cr_data : std_ulogic_vector(31 downto 0);
 	end record;
-	constant WritebackToCrFileInit : WritebackToCrFileType := (write_cr_enable => '0', others => (others => '0'));
+	constant WritebackToCrFileInit : WritebackToCrFileType := (write_cr_enable => '0', others => (others => '-'));
 
 	-- Would prefer not to expose this outside the register file, but ghdl
 	-- doesn't support external names

--- a/common.vhdl
+++ b/common.vhdl
@@ -129,7 +129,7 @@ package common is
 		write_reg : std_ulogic_vector(4 downto 0);
 		write_data : std_ulogic_vector(63 downto 0);
 	end record;
-	constant Loadstore2ToWritebackInit : Loadstore2ToWritebackType := (valid => '0', write_enable => '0', others => (others => '0'));
+	constant Loadstore2ToWritebackInit : Loadstore2ToWritebackType := (valid => '0', write_enable => '0', others => (others => '-'));
 
 	type Execute1ToExecute2Type is record
 		valid: std_ulogic;

--- a/common.vhdl
+++ b/common.vhdl
@@ -171,7 +171,7 @@ package common is
 		write_data : std_ulogic_vector(63 downto 0);
 		write_enable : std_ulogic;
 	end record;
-	constant WritebackToRegisterFileInit : WritebackToRegisterFileType := (write_enable => '0', others => (others => '0'));
+	constant WritebackToRegisterFileInit : WritebackToRegisterFileType := (write_enable => '0', others => (others => '-'));
 
 	type WritebackToCrFileType is record
 		write_cr_enable : std_ulogic;

--- a/common.vhdl
+++ b/common.vhdl
@@ -63,7 +63,7 @@ package common is
 		data2: std_ulogic_vector(64 downto 0);
 		rc: std_ulogic;
 	end record;
-	constant Decode2ToMultiplyInit : Decode2ToMultiplyType := (valid => '0', insn_type => OP_ILLEGAL, rc => '0', others => (others => '0'));
+	constant Decode2ToMultiplyInit : Decode2ToMultiplyType := (valid => '0', insn_type => OP_ILLEGAL, rc => '0', others => (others => '-'));
 
 	type Decode2ToRegisterFileType is record
 		read1_enable : std_ulogic;

--- a/common.vhdl
+++ b/common.vhdl
@@ -141,7 +141,7 @@ package common is
 		write_cr_data : std_ulogic_vector(31 downto 0);
 		rc : std_ulogic;
 	end record;
-	constant Execute1ToExecute2Init : Execute1ToExecute2Type := (valid => '0', write_enable => '0', write_cr_enable => '0', rc => '0', others => (others => '0'));
+	constant Execute1ToExecute2Init : Execute1ToExecute2Type := (valid => '0', write_enable => '0', write_cr_enable => '0', rc => '0', others => (others => '-'));
 
 	type Execute2ToWritebackType is record
 		valid: std_ulogic;

--- a/helpers.vhdl
+++ b/helpers.vhdl
@@ -29,59 +29,47 @@ end package helpers;
 
 package body helpers is
 	function fls_32 (val: std_ulogic_vector(31 downto 0)) return integer is
-		variable ret: integer;
 	begin
-		ret := 32;
 		for i in val'range loop
 			if val(i) = '1' then
-				ret := 31 - i;
-				exit;
+				return 31 - i;
 			end if;
 		end loop;
 
-		return ret;
+		return 32;
 	end;
 
 	function ffs_32 (val: std_ulogic_vector(31 downto 0)) return integer is
-		variable ret: integer;
 	begin
-		ret := 32;
 		for i in val'reverse_range loop
 			if val(i) = '1' then
-				ret := i;
-				exit;
+				return i;
 			end if;
 		end loop;
 
-		return ret;
+		return 32;
 	end;
 
 	function fls_64 (val: std_ulogic_vector(63 downto 0)) return integer is
-		variable ret: integer;
 	begin
-		ret := 64;
 		for i in val'range loop
 			if val(i) = '1' then
-				ret := 63 - i;
-				exit;
+				return 63 - i;
 			end if;
 		end loop;
 
-		return ret;
+		return 64;
 	end;
 
 	function ffs_64 (val: std_ulogic_vector(63 downto 0)) return integer is
-		variable ret: integer;
 	begin
-		ret := 64;
 		for i in val'reverse_range loop
 			if val(i) = '1' then
-				ret := i;
-				exit;
+				return i;
 			end if;
 		end loop;
 
-		return ret;
+		return 64;
 	end;
 
 	function popcnt8(val: std_ulogic_vector(7 downto 0)) return std_ulogic_vector is


### PR DESCRIPTION
This series includes some small changes that overall give a 15% reduction in the core size. Most of this is gained in execute1 which is 28% smaller.

I've split this into a large series so any problems can be more easily isolated. The Execute1ToFetch1TypeInit and Execute1ToExecute2Init give by far the biggest gains. The other changes don't help that much.

One small cleanup patch to the ffs/fls_32/64 functions is also included.

Passes `make check`