### PR TITLE
Don't send out X state from the memory behavioural

### DIFF
--- a/simple_ram_behavioural.vhdl
+++ b/simple_ram_behavioural.vhdl
@@ -41,7 +41,7 @@ begin
 				state <= IDLE;
 				ret_ack <= '0';
 			else
-				ret_dat := x"XXXXXXXXXXXXXXXX";
+				ret_dat := x"FFFFFFFFFFFFFFFF";
 
 				-- Active
 				if wishbone_in.cyc = '1' then


### PR DESCRIPTION
Just send out all 1s.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>