### PR TITLE
Allow a full make check on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ services: docker
 
 before_install: docker pull ghdl/vunit:llvm
 
-script: docker run --rm -t -v `pwd`:/build -w /build ghdl/vunit:llvm bash -c "apt update && apt install -y python3-pexpect && make GNATMAKE='gnatmake -j'$(nproc) && make -j$(nproc) check_light"
+script: docker run --rm -t -v `pwd`:/build -w /build ghdl/vunit:llvm bash -c "apt update && apt install -y python3-pexpect && make GNATMAKE='gnatmake -j'$(nproc) && if [ -n \"$TRAVIS_FULL_CHECK\" ] ; then  make -j$(nproc) check; else make -j$(nproc) check_light ; fi"


### PR DESCRIPTION
Some Travis instances allow more CPU time. On these we can perform the
full 'make check'.

This patch allows this longer `make check`. To enable it you need to
go into your Travis configuration and add a TRAVIS_FULL_CHECK
environment variable.

If you don't add this environment, the shorter make check_light is
still run.

Signed-off-by: Michael Neuling <mikey@neuling.org>