### PR TITLE
Remove nia from loadstore and multiply

### DIFF
--- a/common.vhdl
+++ b/common.vhdl
@@ -56,7 +56,6 @@ package common is
 	type Decode2ToMultiplyType is record
 		valid: std_ulogic;
 		insn_type: insn_type_t;
-		nia: std_ulogic_vector(63 downto 0);
 		write_reg: std_ulogic_vector(4 downto 0);
 		data1: std_ulogic_vector(64 downto 0);
 		data2: std_ulogic_vector(64 downto 0);
@@ -95,7 +94,6 @@ package common is
 
 	type Decode2ToLoadstore1Type is record
 		valid : std_ulogic;
-		nia: std_ulogic_vector(63 downto 0);
 		load : std_ulogic;				-- is this a load or store
 		addr1 : std_ulogic_vector(63 downto 0);
 		addr2 : std_ulogic_vector(63 downto 0);

--- a/decode2.vhdl
+++ b/decode2.vhdl
@@ -188,13 +188,7 @@ begin
 	decode2_0: process(clk)
 	begin
 		if rising_edge(clk) then
-			if rin.e.valid = '1' then
-				report "execute " & to_hstring(rin.e.nia);
-			end if;
-			if rin.l.valid = '1' then
-				report "execute " & to_hstring(rin.e.nia);
-			end if;
-			if rin.m.valid = '1' then
+			if rin.e.valid = '1' or rin.l.valid = '1' or rin.m.valid = '1' then
 				report "execute " & to_hstring(rin.e.nia);
 			end if;
 			r <= rin;
@@ -268,7 +262,6 @@ begin
 		v.e.const3 := decode_const_c(d_in.decode.const_c, d_in.insn);
 
 		-- multiply unit
-		v.m.nia := d_in.nia;
 		v.m.insn_type := d_in.decode.insn_type;
 		mul_a := decoded_reg_a.data;
 		mul_b := decoded_reg_b.data;
@@ -296,7 +289,6 @@ begin
 		end if;
 
 		-- load/store unit
-		v.l.nia := d_in.nia;
 		v.l.update_reg := decoded_reg_a.reg;
 		v.l.addr1 := decoded_reg_a.data;
 		v.l.addr2 := decoded_reg_b.data;


### PR DESCRIPTION
Neither unit needs the NIA, so remove it.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>