### PR TITLE
Remove names from end record statements

### DIFF
--- a/fpga/clk_gen_mcmm.vhd
+++ b/fpga/clk_gen_mcmm.vhd
@@ -22,7 +22,7 @@ architecture rtl of clock_generator is
         clkfbout_mult : real range 2.0 to 64.0;
         clkout_divide : real range 1.0 to 128.0;
         divclk_divide : integer range 1 to 106;
-    end record pll_settings_t;
+    end record;
 
     function gen_pll_settings (
         constant freq_hz : positive)

--- a/fpga/clk_gen_plle2.vhd
+++ b/fpga/clk_gen_plle2.vhd
@@ -23,7 +23,7 @@ architecture rtl of clock_generator is
     clkfbout_mult : integer range 2 to 64;
     clkout_divide : integer range 1 to 128;
     divclk_divide : integer range 1 to 56;
-  end record pll_settings_t;
+  end record;
 
   function gen_pll_settings (
     constant freq_hz : positive)

--- a/wishbone_types.vhdl
+++ b/wishbone_types.vhdl
@@ -15,13 +15,13 @@ package wishbone_types is
 		stb : std_ulogic;
 		sel : std_ulogic_vector(7 downto 0);
 		we  : std_ulogic;
-	end record wishbone_master_out;
+	end record;
 	constant wishbone_master_out_init : wishbone_master_out := (cyc => '0', stb => '0', we => '0', others => (others => '0'));
 
 	type wishbone_slave_out is record
 		dat : wishbone_data_type;
 		ack : std_ulogic;
-	end record wishbone_slave_out;
+	end record;
 	constant wishbone_slave_out_init : wishbone_slave_out := (ack => '0', others => (others => '0'));
 
 end package wishbone_types;


### PR DESCRIPTION
These are optional, and vhdlpp from iverilog barfs on them.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>