### PR TITLE
Explicitly check against '1' in if statements

### DIFF
--- a/decode1.vhdl
+++ b/decode1.vhdl
@@ -248,7 +248,7 @@ begin
 
 		ppc_insn := PPC_ILLEGAL;
 
-		if f_in.valid then
+		if f_in.valid = '1' then
 			v.nia  := f_in.nia;
 			v.insn := f_in.insn;
 

--- a/decode2.vhdl
+++ b/decode2.vhdl
@@ -260,7 +260,7 @@ begin
 		v.e.cr := c_in.read_cr_data;
 		v.e.input_carry := d_in.decode.input_carry;
 		v.e.output_carry := d_in.decode.output_carry;
-		if d_in.decode.lr then
+		if d_in.decode.lr = '1' then
 			v.e.lr := insn_lk(d_in.insn);
 		end if;
 		v.e.const1 := decode_const_a(d_in.decode.const_a, d_in.insn);


### PR DESCRIPTION
nvc doesn't like what I think is a VHDL 2008 construct. Lets just
check against '1' explicitly.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>