### PR TITLE
Fix clk_gen_bypass

### DIFF
--- a/fpga/clk_gen_bypass.vhd
+++ b/fpga/clk_gen_bypass.vhd
@@ -14,7 +14,7 @@ architecture bypass of clock_generator is
 
 begin
 
-  pll_locked_out <= pll_rst_in;
+  pll_locked_out <= not pll_rst_in;
   pll_clk_out <= ext_clk;
 
 end architecture bypass;


### PR DESCRIPTION
I broke clk_gen_bypass when updating the SOC reset code.

Fixes 03fd06deaf9f ("Rework SOC reset")
Signed-off-by: Anton Blanchard <anton@linux.ibm.com>