### PR TITLE
Fix make check

### DIFF
--- a/decode1.vhdl
+++ b/decode1.vhdl
@@ -217,7 +217,7 @@ architecture behaviour of decode1 is
 		PPC_SYNC       =>       (ALU,    OP_NOP,       NONE,       NONE,        NONE, NONE, NONE, NONE, NONE, '0', '0', '0', '0', NONE, '0', '0', '0', '0', '0', '0', NONE, '0', '1'),
 		--PPC_TD
 		PPC_TDI        =>       (ALU,    OP_TDI,       RA,         CONST_SI,    NONE, NONE, TOO,  NONE, NONE, '0', '0', '0', '0', NONE, '0', '0', '0', '0', '0', '0', NONE, '0', '1'),
-		--PPC_TW
+		PPC_TW         =>       (ALU,    OP_TW,        RA,         RB,          NONE, NONE, TOO,  NONE, NONE, '0', '0', '0', '0', NONE, '0', '0', '0', '0', '0', '0', NONE, '0', '1'),
 		--PPC_TWI
 		PPC_XOR        =>       (ALU,    OP_XOR,       RS,         RB,          NONE, RA,   NONE, NONE, NONE, '0', '0', '0', '0', NONE, '0', '0', '0', '0', '0', '0', RC,   '0', '1'),
 		PPC_XORI       =>       (ALU,    OP_XOR,       RS,         CONST_UI,    NONE, RA,   NONE, NONE, NONE, '0', '0', '0', '0', NONE, '0', '0', '0', '0', '0', '0', NONE, '0', '1'),


### PR DESCRIPTION
We need to finish support for all the trap instructions, but for now
we at least need a decode entry for tw, so we know to stall until the
previous instruction completes. Some of our test cases were failing
because the trap executed before the previous instruction completed.

All these trap instructions need to be resolved at completion, not
in execute.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>