### PR TITLE
Move byte reversal of stores to first cycle

### DIFF
--- a/loadstore1.vhdl
+++ b/loadstore1.vhdl
@@ -4,6 +4,7 @@ use ieee.numeric_std.all;
 
 library work;
 use work.common.all;
+use work.helpers.all;
 
 -- 2 cycle LSU
 -- We calculate the address in the first cycle
@@ -46,6 +47,11 @@ begin
 		v.sign_extend := l_in.sign_extend;
 		v.update := l_in.update;
 		v.update_reg := l_in.update_reg;
+
+		-- byte reverse stores in the first cycle
+		if v.load = '0' and l_in.byte_reverse = '1' then
+			v.data := byte_reverse(l_in.data, to_integer(unsigned(l_in.length)));
+		end if;
 
 		v.addr := lsu_sum;
 

--- a/loadstore2.vhdl
+++ b/loadstore2.vhdl
@@ -102,10 +102,6 @@ begin
 						m_tmp.we <= '1';
 
 						data := l_in.data;
-						if l_in.byte_reverse = '1' then
-							data := byte_reverse(data, to_integer(unsigned(l_in.length)));
-						end if;
-
 						m_tmp.dat <= std_logic_vector(shift_left(unsigned(data), wishbone_data_shift(l_in.addr)));
 
 						assert l_in.sign_extend = '0' report "sign extension doesn't make sense for stores" severity failure;


### PR DESCRIPTION
We are seeing some timing issues with the second cycle of loadstore,
and  we aren't doing much in the first cycle, so move it here.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>