### PR TITLE
fpga: Add definitions for Arty A7-100 board

### DIFF
--- a/microwatt.core
+++ b/microwatt.core
@@ -73,6 +73,11 @@ filesets:
       - fpga/arty_a7-35.xdc : {file_type : xdc}
       - fpga/clk_gen_plle2.vhd : {file_type : vhdlSource-2008}
 
+  arty_a7-100:
+    files:
+      - fpga/arty_a7-35.xdc : {file_type : xdc}
+      - fpga/clk_gen_plle2.vhd : {file_type : vhdlSource-2008}
+
   cmod_a7-35:
     files:
       - fpga/cmod_a7-35.xdc : {file_type : xdc}
@@ -101,6 +106,14 @@ targets:
     parameters : [memory_size, ram_init_file]
     tools:
       vivado: {part : xc7a35ticsg324-1L}
+    toplevel : toplevel
+
+  arty_a7-100:
+    default_tool: vivado
+    filesets: [core, arty_a7-100, soc, fpga, debug_xilinx]
+    parameters : [memory_size, ram_init_file]
+    tools:
+      vivado: {part : xc7a100ticsg324-1L}
     toplevel : toplevel
 
   cmod_a7-35:


### PR DESCRIPTION
These are a copy of the A7-35 definitions with 35 changed to 100.
The A7-100 uses the same .xdc file (arty_a7-35.xdc) as the A7-35
since the only difference between the two is the FPGA part; the
hardware and connections on the two boards are identical.

Signed-off-by: Paul Mackerras <paulus@ozlabs.org>