### PR TITLE
Limit outstanding range

### DIFF
--- a/decode2.vhdl
+++ b/decode2.vhdl
@@ -40,7 +40,7 @@ architecture behaviour of decode2 is
 
 	type reg_internal_type is record
 		state : state_type;
-		outstanding : integer;
+		outstanding : integer range -1 to 2;
 	end record;
 
 	type reg_type is record


### PR DESCRIPTION
outstanding can only ever be -1 to 2 at the moment (0 or 1 on a
rising clock edge). Vivado is synthesizing a much wider adder
which is silly. Constrain it with a range statement. This should
be good for timing and saves us about 85 LUTs.

This will get relaxed when we add more pipelining, but only by a
few bits.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>