### PR TITLE
Fix cmod-a7 frequency

### DIFF
--- a/microwatt.core
+++ b/microwatt.core
@@ -139,6 +139,7 @@ targets:
       - ram_init_file
       - reset_low=false
       - clk_input=12000000
+      - clk_frequency
     tools:
       vivado: {part : xc7a35tcpg236-1}
     toplevel : toplevel


### PR DESCRIPTION
The cmod-a7 is ignoring the clk_frequency parameter and running at
100 MHz. Fix it.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>