### PR TITLE
Don't infer latch for newcrf

### DIFF
--- a/execute1.vhdl
+++ b/execute1.vhdl
@@ -121,6 +121,7 @@ begin
 		result := (others => '0');
 		result_with_carry := (others => '0');
 		result_en := 0;
+		newcrf := (others => '0');
 
 		v := r;
 		v.e := Execute1ToExecute2Init;


### PR DESCRIPTION
Always initialize newcrf to avoid inferring a latch.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>