### PR TITLE
Fix clk_gen_bypass

### DIFF
--- a/fpga/clk_gen_bypass.vhd
+++ b/fpga/clk_gen_bypass.vhd
@@ -2,6 +2,11 @@ library ieee;
 use ieee.std_logic_1164.all;
 
 entity clock_generator is
+    generic (
+        CLK_INPUT_HZ  : positive := 50000000;
+        CLK_OUTPUT_HZ : positive := 50000000
+        );
+
   port (
     ext_clk        : in  std_logic;
     pll_rst_in   : in  std_logic;
@@ -13,8 +18,8 @@ end entity clock_generator;
 architecture bypass of clock_generator is
 
 begin
+    assert CLK_INPUT_HZ = CLK_OUTPUT_HZ severity FAILURE;
 
-  pll_locked_out <= not pll_rst_in;
-  pll_clk_out <= ext_clk;
-
+    pll_locked_out <= not pll_rst_in;
+    pll_clk_out <= ext_clk;
 end architecture bypass;


### PR DESCRIPTION
clk_gen_bypass needed updating after the addition of CLK_INPUT_HZ and
CLK_OUTPUT_HZ.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>