### PR TITLE
Remove SIM generic from execute1

### DIFF
--- a/core.vhdl
+++ b/core.vhdl
@@ -195,9 +195,6 @@ begin
             );
 
     execute1_0: entity work.execute1
-        generic map (
-            SIM => SIM
-            )
         port map (
             clk => clk,
             flush_out => flush,

--- a/execute1.vhdl
+++ b/execute1.vhdl
@@ -11,9 +11,6 @@ use work.insn_helpers.all;
 use work.ppc_fx_insns.all;
 
 entity execute1 is
-    generic (
-	SIM   : boolean := false
-	);
     port (
 	clk   : in std_logic;
 
@@ -334,11 +331,7 @@ begin
 	    when OP_SIM_CONFIG =>
 		-- bit 0 was used to select the microwatt console, which
 		-- we no longer support.
-		if SIM = true then
-		    result := x"0000000000000000";
-		else
-		    result := x"0000000000000000";
-		end if;
+		result := x"0000000000000000";
 		result_en := '1';
 
 	    when OP_TDI =>


### PR DESCRIPTION
This does nothing, so remove.

Signed-off-by: Michael Neuling <mikey@neuling.org>