### PR TITLE
control: Reduce pipeline depth to 1

### DIFF
--- a/control.vhdl
+++ b/control.vhdl
@@ -57,7 +57,7 @@ architecture rtl of control is
 begin
     gpr_hazard0: entity work.gpr_hazard
         generic map (
-            PIPELINE_DEPTH => 2
+            PIPELINE_DEPTH => PIPELINE_DEPTH
             )
         port map (
             clk                => clk,
@@ -72,7 +72,7 @@ begin
 
     gpr_hazard1: entity work.gpr_hazard
         generic map (
-            PIPELINE_DEPTH => 2
+            PIPELINE_DEPTH => PIPELINE_DEPTH
             )
         port map (
             clk                => clk,
@@ -87,7 +87,7 @@ begin
 
     gpr_hazard2: entity work.gpr_hazard
         generic map (
-            PIPELINE_DEPTH => 2
+            PIPELINE_DEPTH => PIPELINE_DEPTH
             )
         port map (
             clk                => clk,
@@ -102,7 +102,7 @@ begin
 
     cr_hazard0: entity work.cr_hazard
         generic map (
-            PIPELINE_DEPTH => 2
+            PIPELINE_DEPTH => PIPELINE_DEPTH
             )
         port map (
             clk                => clk,

--- a/decode2.vhdl
+++ b/decode2.vhdl
@@ -152,7 +152,7 @@ architecture behaviour of decode2 is
 begin
 	control_0: entity work.control
 	generic map (
-		PIPELINE_DEPTH => 2
+		PIPELINE_DEPTH => 1
 	)
 	port map (
 		clk         => clk,


### PR DESCRIPTION
To match our one stage execute.

This might change back if we end up adding 2 stages to match the
LSU, but in that case we'll want forwards as well.

Signed-off-by: Benjamin Herrenschmidt <benh@kernel.crashing.org>