### PR TITLE
make the sources volume mount SELinux friendly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CFLAGS=-O2 -Wall
 #
 # Uncomment these lines to build with Docker/podman
 #PWD = $(shell pwd)
-#DOCKERARGS = run --rm -v $(PWD):/src -w /src
+#DOCKERARGS = run --rm -v $(PWD):/src:z -w /src
 #GHDL = $(DOCKER) $(DOCKERARGS) ghdl/ghdl:buster-llvm-7 ghdl
 #CC = $(DOCKER) $(DOCKERARGS) ghdl/ghdl:buster-llvm-7 gcc
 

--- a/Makefile.synth
+++ b/Makefile.synth
@@ -10,7 +10,7 @@ DOCKER=docker
 #DOCKER=podman
 #
 PWD = $(shell pwd)
-DOCKERARGS = run --rm -v $(PWD):/src -w /src
+DOCKERARGS = run --rm -v $(PWD):/src:z -w /src
 #
 GHDLSYNTH = ghdl
 YOSYS     = $(DOCKER) $(DOCKERARGS) ghdl/synth:beta yosys


### PR DESCRIPTION
Tested on Fedora 30 with podman, but should work with docker too. Without that yosys can't access the vhdl sources.