### PR TITLE
gitignore: Fix RAM file name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 *.cf
 *.s
 *_tb
-simple_ram_behavioural.bin
+main_ram.bin


### PR DESCRIPTION
From:
    commit 8e0389b9736c60572e13ef5eeb50d3a775c3ffc6
    Author: Benjamin Herrenschmidt <benh@kernel.crashing.org>
    Date:   Wed Oct 23 12:08:55 2019 +1100
    ram: Rework main RAM interface

We need to change the name from simple_ram_behavioural.bin to main_ram.bin.