### PR TITLE
icache: Fix icbi potentially clobbering the icache

### DIFF
--- a/core.vhdl
+++ b/core.vhdl
@@ -159,7 +159,7 @@ begin
         if rising_edge(clk) then
             rst_fetch1  <= core_rst;
             rst_fetch2  <= core_rst;
-            rst_icache  <= core_rst or dbg_icache_rst or ex1_icache_inval;
+            rst_icache  <= core_rst;
             rst_dcache  <= core_rst;
             rst_dec1    <= core_rst;
             rst_dec2    <= core_rst;
@@ -202,6 +202,7 @@ begin
             i_out => icache_to_fetch2,
             m_in => mmu_to_icache,
             flush_in => flush,
+            inval_in => dbg_icache_rst or ex1_icache_inval,
 	    stall_out => icache_stall_out,
             wishbone_out => wishbone_insn_out,
             wishbone_in => wishbone_insn_in

--- a/icache_tb.vhdl
+++ b/icache_tb.vhdl
@@ -34,6 +34,7 @@ begin
             i_out => i_in,
             m_in => m_out,
 	    flush_in => '0',
+            inval_in => '0',
             wishbone_out => wb_bram_in,
             wishbone_in => wb_bram_out
             );


### PR DESCRIPTION
icbi currently just resets the icache. This has some nasty side
effects such as also clearing the TLB, but also the wishbone interface.

That means that any ongoing cycle will be dropped.

However, most of our slaves don't handle that well and will continue
sending acks for already issued requests.

Under some circumstances we can thus restart an icache load and get
spurious ack/data from the wishbone left over from the "cancelled"
sequence.

This has broken booting Linux for me.

Signed-off-by: Benjamin Herrenschmidt <benh@kernel.crashing.org>