### PR TITLE
Makefile: Improve unisim library generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GHDL ?= ghdl
-GHDLFLAGS=--std=08 --work=unisim -frelaxed
+GHDLFLAGS=--std=08 -frelaxed
 CFLAGS=-O3 -Wall
 
 GHDLSYNTH ?= ghdl.so
@@ -54,12 +54,17 @@ soc_files = wishbone_arbiter.vhdl wishbone_bram_wrapper.vhdl sync_fifo.vhdl \
 	wishbone_debug_master.vhdl xics.vhdl syscon.vhdl soc.vhdl
 
 soc_sim_files = sim_console.vhdl sim_uart.vhdl sim_bram_helpers.vhdl \
-	sim_bram.vhdl sim_jtag_socket.vhdl sim_jtag.vhdl \
-	sim-unisim/BSCANE2.vhdl sim-unisim/BUFG.vhdl \
-	sim-unisim/unisim_vcomponents.vhdl dmi_dtm_xilinx.vhdl
+	sim_bram.vhdl sim_jtag_socket.vhdl sim_jtag.vhdl dmi_dtm_xilinx.vhdl
+
+unisim_lib = sim-unisim/unisim-obj08.cf
+unisim_lib_files = sim-unisim/BSCANE2.vhdl sim-unisim/BUFG.vhdl \
+	sim-unisim/unisim_vcomponents.vhdl
+$(unisim_lib): $(unisim_lib_files)
+	ghdl -i --std=08 --work=unisim --workdir=sim-unisim $^
 
 soc_sim_c_files = sim_vhpi_c.c sim_bram_helpers_c.c sim_console_c.c \
 	sim_jtag_socket_c.c
+
 soc_sim_obj_files=$(soc_sim_c_files:.c=.o)
 comma := ,
 soc_sim_link=$(patsubst %,-Wl$(comma)%,$(soc_sim_obj_files))
@@ -68,8 +73,8 @@ core_tbs = multiply_tb divider_tb rotator_tb countzero_tb
 soc_tbs = core_tb icache_tb dcache_tb dmi_dtm_tb wishbone_bram_tb
 soc_dram_tbs = dram_tb core_dram_tb
 
-$(soc_tbs): %: $(core_files) $(soc_files) $(soc_sim_files) $(soc_sim_obj_files) %.vhdl
-	$(GHDL) -c $(GHDLFLAGS) $(soc_sim_link) $(core_files) $(soc_files) $(soc_sim_files) $@.vhdl -e $@
+$(soc_tbs): %: $(core_files) $(soc_files) $(soc_sim_files) $(soc_sim_obj_files) $(unisim_lib) %.vhdl
+	$(GHDL) -c $(GHDLFLAGS) -Psim-unisim $(soc_sim_link) $(core_files) $(soc_files) $(soc_sim_files) $@.vhdl -e $@
 
 $(core_tbs): %: $(core_files) glibc_random.vhdl glibc_random_helpers.vhdl %.vhdl
 	$(GHDL) -c $(GHDLFLAGS) $(core_files) glibc_random.vhdl glibc_random_helpers.vhdl $@.vhdl -e $@
@@ -101,8 +106,8 @@ soc_dram_sim_obj_files = $(soc_sim_obj_files) sim_litedram_c.o
 dram_link_files=-Wl,obj_dir/Vlitedram_core__ALL.a -Wl,obj_dir/verilated.o -Wl,obj_dir/verilated_vcd_c.o -Wl,-lstdc++
 soc_dram_sim_link=$(patsubst %,-Wl$(comma)%,$(soc_dram_sim_obj_files)) $(dram_link_files)
 
-$(soc_dram_tbs): %: $(core_files) $(soc_dram_files) $(soc_dram_sim_files) $(soc_dram_sim_obj_files) %.vhdl
-	$(GHDL) -c $(GHDLFLAGS) $(soc_dram_sim_link) $(core_files) $(soc_dram_files) $(soc_dram_sim_files) $@.vhdl -e $@
+$(soc_dram_tbs): %: $(core_files) $(soc_dram_files) $(soc_dram_sim_files) $(soc_dram_sim_obj_files) $(unisim_lib) %.vhdl
+	$(GHDL) -c $(GHDLFLAGS) -Psim-unisim $(soc_dram_sim_link) $(core_files) $(soc_dram_files) $(soc_dram_sim_files) $@.vhdl -e $@
 endif
 
 # Hello world
@@ -209,9 +214,9 @@ TAGS:
 .PHONY: TAGS
 
 _clean:
-	rm -f *.o work-*cf unisim-*cf $(all)
-	rm -f fpga/*.o fpga/work-*cf
-	rm -f sim-unisim/*.o sim-unisim/unisim-*cf
+	rm -f *.o *.cf $(all)
+	rm -f fpga/*.o fpga/*.cf
+	rm -f sim-unisim/*.o sim-unisim/*.cf
 	rm -f litedram/extras/*.o
 	rm -f TAGS
 	rm -f scripts/mw_debug/*.o


### PR DESCRIPTION
The rewrite of the Makefile to use "ghdl -c" somewhat broke building
the unisim library as ghdl doesn't yet support putting files in
separate libraries from a single command line invocation.

The workaround at the time was to put the entire project in "unisim"
which is ... weird and will break if we try to add another library
such as fmf.

This fixes it by generating the library separately using "ghdl -i"

Signed-off-by: Benjamin Herrenschmidt <benh@kernel.crashing.org>