### PR TITLE
spi: Fix dat_i_l constraints

### DIFF
--- a/fpga/arty_a7.xdc
+++ b/fpga/arty_a7.xdc
@@ -39,7 +39,7 @@ set_property -dict { PACKAGE_PIN M14 IOSTANDARD LVCMOS33 } [get_ports { spi_flas
 
 # Put registers into IOBs to improve timing
 set_property IOB true [get_cells -hierarchical -filter {NAME =~*/spi_rxtx/*sck_1*}]
-set_property IOB true [get_cells -hierarchical -filter {NAME =~*/spi_rxtx/dat_i_l*}]
+set_property IOB true [get_cells -hierarchical -filter {NAME =~*/spi_rxtx/input_delay_1.dat_i_l*}]
 
 
 ################################################################################


### PR DESCRIPTION
No cells matched 'get_cells -hierarchical -filter {NAME =~*/spi_rxtx/dat_i_l*}'. [build/microwatt_0/src/microwatt_0/fpga/arty_a7.xdc:42]

The signal is in it's own process so the net name ends up being
spi_rxtx/input_delay_1.dat_i_l_reg.

After this change the log shows:

Applied set_property IOB = TRUE for soc0/\spiflash_gen.spiflash /spi_rxtx/\input_delay_1.dat_i_l_reg . (constraint file  fpga/arty_a7.xdc, line 42).
Applied set_property IOB = TRUE for soc0/\spiflash_gen.spiflash /spi_rxtx/\input_delay_1.dat_i_l_reg . (constraint file  fpga/arty_a7.xdc, line 42).
Applied set_property IOB = TRUE for soc0/\spiflash_gen.spiflash /spi_rxtx/\input_delay_1.dat_i_l_reg . (constraint file  fpga/arty_a7.xdc, line 42).
Applied set_property IOB = TRUE for soc0/\spiflash_gen.spiflash /spi_rxtx/\input_delay_1.dat_i_l_reg . (constraint file  fpga/arty_a7.xdc, line 42).

Signed-off-by: Joel Stanley <joel@jms.id.au>