### PR TITLE
makefile: use '$(GHDL)' instead of 'ghdl'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ unisim_lib = $(unisim_dir)/unisim-obj08.cf
 unisim_lib_files = $(unisim_dir)/BSCANE2.vhdl $(unisim_dir)/BUFG.vhdl \
 	$(unisim_dir)/unisim_vcomponents.vhdl
 $(unisim_lib): $(unisim_lib_files)
-	ghdl -i --std=08 --work=unisim --workdir=$(unisim_dir) $^
+	$(GHDL) -i --std=08 --work=unisim --workdir=$(unisim_dir) $^
 GHDLFLAGS += -P$(unisim_dir)
 
 core_tbs = multiply_tb divider_tb rotator_tb countzero_tb
@@ -85,7 +85,7 @@ fmf_lib = $(fmf_dir)/fmf-obj08.cf
 fmf_lib_files = $(wildcard $(fmf_dir)/*.vhd)
 GHDLFLAGS += -P$(fmf_dir)
 $(fmf_lib): $(fmf_lib_files)
-	ghdl -i --std=08 --work=fmf --workdir=$(fmf_dir) $^
+	$(GHDL) -i --std=08 --work=fmf --workdir=$(fmf_dir) $^
 
 flash_model_files=$(FLASH_MODEL_PATH)/s25fl128s.vhd
 flash_model_files: $(fmf_lib)
@@ -94,10 +94,10 @@ flash_model_files=sim_no_flash.vhdl
 fmf_lib=
 endif
 
-$(soc_flash_tbs): %: $(soc_sim_files) $(soc_sim_obj_files) $(unisim_lib) $(fmf_lib) $(flash_model_files) %.vhdl 
+$(soc_flash_tbs): %: $(soc_sim_files) $(soc_sim_obj_files) $(unisim_lib) $(fmf_lib) $(flash_model_files) %.vhdl
 	$(GHDL) -c $(GHDLFLAGS) $(soc_sim_link) $(soc_sim_files) $(flash_model_files) $@.vhdl $(unisim_files) -e $@
 
-$(soc_tbs): %: $(soc_sim_files) $(soc_sim_obj_files) $(unisim_lib) %.vhdl 
+$(soc_tbs): %: $(soc_sim_files) $(soc_sim_obj_files) $(unisim_lib) %.vhdl
 	$(GHDL) -c $(GHDLFLAGS) $(soc_sim_link) $(soc_sim_files) $@.vhdl -e $@
 
 $(core_tbs): %: $(core_files) glibc_random.vhdl glibc_random_helpers.vhdl %.vhdl
@@ -130,7 +130,7 @@ soc_dram_sim_obj_files = $(soc_sim_obj_files) sim_litedram_c.o
 dram_link_files=-Wl,obj_dir/Vlitedram_core__ALL.a -Wl,obj_dir/verilated.o -Wl,obj_dir/verilated_vcd_c.o -Wl,-lstdc++
 soc_dram_sim_link=$(patsubst %,-Wl$(comma)%,$(soc_dram_sim_obj_files)) $(dram_link_files)
 
-$(soc_dram_tbs): %: $(soc_dram_files) $(soc_dram_sim_files) $(soc_dram_sim_obj_files) $(flash_model_files) $(unisim_lib) $(fmf_lib) %.vhdl 
+$(soc_dram_tbs): %: $(soc_dram_files) $(soc_dram_sim_files) $(soc_dram_sim_obj_files) $(flash_model_files) $(unisim_lib) $(fmf_lib) %.vhdl
 	$(GHDL) -c $(GHDLFLAGS) $(soc_dram_sim_link) $(soc_dram_files) $(soc_dram_sim_files) $(flash_model_files) $@.vhdl -e $@
 endif
 


### PR DESCRIPTION
Close #218.

This is a minor fix, to ensure that GHDL is called inside docker/podman containers when `DOCKER=1`. Currently, `unisim_lib` and `fmf_lib` are built with `ghdl` (which is always local).

There seems to be a similar issue with targets `$(tests)`, `$(tests_console)`, `test_micropython` or `test_micropython_long`, which are always executed on the host. However, I have not addressed that. As a workaround, I run a container manually, and then execute the script inside.