### PR TITLE
removing vhdl 2008 features to support vivado simulations

### DIFF
--- a/core_debug.vhdl
+++ b/core_debug.vhdl
@@ -182,7 +182,7 @@ begin
                             do_dmi_log_rd <= '1';
 			end if;
 		    else
-			report("DMI read from " & to_string(dmi_addr));
+			report("DMI read from " & to_hstring(dmi_addr));
 		    end if;
 
                 elsif dmi_read_log_data = '0' and dmi_read_log_data_1 = '1' then

--- a/core_debug.vhdl
+++ b/core_debug.vhdl
@@ -145,7 +145,7 @@ begin
 	    do_icreset <= '0';
             do_dmi_log_rd <= '0';
 
-	    if (rst = '1') then
+	    if (rst) then
 		stopping <= '0';
 		terminated <= '0';
 	    else
@@ -182,7 +182,7 @@ begin
                             do_dmi_log_rd <= '1';
 			end if;
 		    else
-			report("DMI read from " & to_hstring(dmi_addr));
+			report("DMI read from " & to_string(dmi_addr));
 		    end if;
 
                 elsif dmi_read_log_data = '0' and dmi_read_log_data_1 = '1' then

--- a/core_debug.vhdl
+++ b/core_debug.vhdl
@@ -145,7 +145,7 @@ begin
 	    do_icreset <= '0';
             do_dmi_log_rd <= '0';
 
-	    if (rst) then
+	    if (rst = '1') then
 		stopping <= '0';
 		terminated <= '0';
 	    else
@@ -182,7 +182,7 @@ begin
                             do_dmi_log_rd <= '1';
 			end if;
 		    else
-			report("DMI read from " & to_string(dmi_addr));
+			report("DMI read from " & to_hstring(dmi_addr));
 		    end if;
 
                 elsif dmi_read_log_data = '0' and dmi_read_log_data_1 = '1' then

--- a/core_debug.vhdl
+++ b/core_debug.vhdl
@@ -145,7 +145,7 @@ begin
 	    do_icreset <= '0';
             do_dmi_log_rd <= '0';
 
-	    if (rst) then
+	    if (rst = '1') then
 		stopping <= '0';
 		terminated <= '0';
 	    else

--- a/execute1.vhdl
+++ b/execute1.vhdl
@@ -505,11 +505,30 @@ begin
 	-- Next insn adder used in a couple of places
 	next_nia := std_ulogic_vector(unsigned(e_in.nia) + 4);
 
-	-- rotator control signals
-	right_shift <= '1' when e_in.insn_type = OP_SHR else '0';
-	rot_clear_left <= '1' when e_in.insn_type = OP_RLC or e_in.insn_type = OP_RLCL else '0';
-	rot_clear_right <= '1' when e_in.insn_type = OP_RLC or e_in.insn_type = OP_RLCR else '0';
-        rot_sign_ext <= '1' when e_in.insn_type = OP_EXTSWSLI else '0';
+    -- rotator control signals
+    if ( (e_in.insn_type = OP_SHR) ) then
+        right_shift <= '1';
+        else
+        right_shift <= '0';
+    end if;
+
+    if ( e_in.insn_type = OP_RLC ) then
+        rot_clear_left <= '1';
+        else
+        rot_clear_left <= '0';
+    end if;
+
+    if ( (e_in.insn_type = OP_RLC) or (e_in.insn_type = OP_RLCR) ) then
+        rot_clear_right <= '1';
+        else
+        rot_clear_right <= '0';
+    end if;
+
+    if ( e_in.insn_type = OP_EXTSWSLI ) then
+        rot_sign_ext <= '1';
+        else
+        rot_sign_ext <= '0';
+    end if;
 
         ctrl_tmp.srr1 <= msr_copy(ctrl.msr);
 	ctrl_tmp.irq_state <= WRITE_SRR0;
@@ -845,7 +864,7 @@ begin
 		report "MFSPR to SPR " & integer'image(decode_spr_num(e_in.insn)) &
 		    "=" & to_hstring(a_in);
 		result_en := '1';
-		if is_fast_spr(e_in.read_reg1) then
+		if (is_fast_spr(e_in.read_reg1) = '1') then
 		    result := a_in;
 		    if decode_spr_num(e_in.insn) = SPR_XER then
 			-- bits 0:31 and 35:43 are treated as reserved and return 0s when read using mfxer
@@ -934,7 +953,7 @@ begin
 	    when OP_MTSPR =>
 		report "MTSPR to SPR " & integer'image(decode_spr_num(e_in.insn)) &
 		    "=" & to_hstring(c_in);
-		if is_fast_spr(e_in.write_reg) then
+		if ( is_fast_spr(e_in.write_reg) = '1' ) then
 		    result := c_in;
 		    result_en := '1';
 		    if decode_spr_num(e_in.insn) = SPR_XER then

--- a/execute1.vhdl
+++ b/execute1.vhdl
@@ -507,27 +507,27 @@ begin
 
     -- rotator control signals
     if ( (e_in.insn_type = OP_SHR) ) then
-        right_shift <= '1';
+            right_shift <= '1';
         else
-        right_shift <= '0';
+            right_shift <= '0';
     end if;
 
-    if ( e_in.insn_type = OP_RLC ) then
-        rot_clear_left <= '1';
+     if ( (e_in.insn_type = OP_RLC) or (e_in.insn_type = OP_RLCR) ) then
+            rot_clear_left <= '1';
         else
-        rot_clear_left <= '0';
+            rot_clear_left <= '0';
     end if;
 
     if ( (e_in.insn_type = OP_RLC) or (e_in.insn_type = OP_RLCR) ) then
-        rot_clear_right <= '1';
+            rot_clear_right <= '1';
         else
-        rot_clear_right <= '0';
+            rot_clear_right <= '0';
     end if;
 
     if ( e_in.insn_type = OP_EXTSWSLI ) then
-        rot_sign_ext <= '1';
+            rot_sign_ext <= '1';
         else
-        rot_sign_ext <= '0';
+            rot_sign_ext <= '0';
     end if;
 
         ctrl_tmp.srr1 <= msr_copy(ctrl.msr);

--- a/execute1.vhdl
+++ b/execute1.vhdl
@@ -512,7 +512,7 @@ begin
             right_shift <= '0';
     end if;
 
-     if ( (e_in.insn_type = OP_RLC) or (e_in.insn_type = OP_RLCR) ) then
+     if ( (e_in.insn_type = OP_RLC) or (e_in.insn_type = OP_RLCL) ) then
             rot_clear_left <= '1';
         else
             rot_clear_left <= '0';

--- a/execute1.vhdl
+++ b/execute1.vhdl
@@ -864,7 +864,7 @@ begin
 		report "MFSPR to SPR " & integer'image(decode_spr_num(e_in.insn)) &
 		    "=" & to_hstring(a_in);
 		result_en := '1';
-		if is_fast_spr(e_in.read_reg1) then
+		if (is_fast_spr(e_in.read_reg1) = '1') then
 		    result := a_in;
 		    if decode_spr_num(e_in.insn) = SPR_XER then
 			-- bits 0:31 and 35:43 are treated as reserved and return 0s when read using mfxer
@@ -953,7 +953,7 @@ begin
 	    when OP_MTSPR =>
 		report "MTSPR to SPR " & integer'image(decode_spr_num(e_in.insn)) &
 		    "=" & to_hstring(c_in);
-		if is_fast_spr(e_in.write_reg) then
+		if ( is_fast_spr(e_in.write_reg) = '1' ) then
 		    result := c_in;
 		    result_en := '1';
 		    if decode_spr_num(e_in.insn) = SPR_XER then

--- a/execute1.vhdl
+++ b/execute1.vhdl
@@ -505,11 +505,30 @@ begin
 	-- Next insn adder used in a couple of places
 	next_nia := std_ulogic_vector(unsigned(e_in.nia) + 4);
 
-	-- rotator control signals
-	right_shift <= '1' when e_in.insn_type = OP_SHR else '0';
-	rot_clear_left <= '1' when e_in.insn_type = OP_RLC or e_in.insn_type = OP_RLCL else '0';
-	rot_clear_right <= '1' when e_in.insn_type = OP_RLC or e_in.insn_type = OP_RLCR else '0';
-        rot_sign_ext <= '1' when e_in.insn_type = OP_EXTSWSLI else '0';
+    -- rotator control signals
+    if ( (e_in.insn_type = OP_SHR) ) then
+        right_shift <= '1';
+        else
+        right_shift <= '0';
+    end if;
+
+    if ( e_in.insn_type = OP_RLC ) then
+        rot_clear_left <= '1';
+        else
+        rot_clear_left <= '0';
+    end if;
+
+    if ( (e_in.insn_type = OP_RLC) or (e_in.insn_type = OP_RLCR) ) then
+        rot_clear_right <= '1';
+        else
+        rot_clear_right <= '0';
+    end if;
+
+    if ( e_in.insn_type = OP_EXTSWSLI ) then
+        rot_sign_ext <= '1';
+        else
+        rot_sign_ext <= '0';
+    end if;
 
         ctrl_tmp.srr1 <= msr_copy(ctrl.msr);
 	ctrl_tmp.irq_state <= WRITE_SRR0;

--- a/execute1.vhdl
+++ b/execute1.vhdl
@@ -505,30 +505,11 @@ begin
 	-- Next insn adder used in a couple of places
 	next_nia := std_ulogic_vector(unsigned(e_in.nia) + 4);
 
-    -- rotator control signals
-    if ( (e_in.insn_type = OP_SHR) ) then
-        right_shift <= '1';
-        else
-        right_shift <= '0';
-    end if;
-
-    if ( e_in.insn_type = OP_RLC ) then
-        rot_clear_left <= '1';
-        else
-        rot_clear_left <= '0';
-    end if;
-
-    if ( (e_in.insn_type = OP_RLC) or (e_in.insn_type = OP_RLCR) ) then
-        rot_clear_right <= '1';
-        else
-        rot_clear_right <= '0';
-    end if;
-
-    if ( e_in.insn_type = OP_EXTSWSLI ) then
-        rot_sign_ext <= '1';
-        else
-        rot_sign_ext <= '0';
-    end if;
+	-- rotator control signals
+	right_shift <= '1' when e_in.insn_type = OP_SHR else '0';
+	rot_clear_left <= '1' when e_in.insn_type = OP_RLC or e_in.insn_type = OP_RLCL else '0';
+	rot_clear_right <= '1' when e_in.insn_type = OP_RLC or e_in.insn_type = OP_RLCR else '0';
+        rot_sign_ext <= '1' when e_in.insn_type = OP_EXTSWSLI else '0';
 
         ctrl_tmp.srr1 <= msr_copy(ctrl.msr);
 	ctrl_tmp.irq_state <= WRITE_SRR0;
@@ -864,7 +845,7 @@ begin
 		report "MFSPR to SPR " & integer'image(decode_spr_num(e_in.insn)) &
 		    "=" & to_hstring(a_in);
 		result_en := '1';
-		if (is_fast_spr(e_in.read_reg1) = '1') then
+		if is_fast_spr(e_in.read_reg1) then
 		    result := a_in;
 		    if decode_spr_num(e_in.insn) = SPR_XER then
 			-- bits 0:31 and 35:43 are treated as reserved and return 0s when read using mfxer
@@ -953,7 +934,7 @@ begin
 	    when OP_MTSPR =>
 		report "MTSPR to SPR " & integer'image(decode_spr_num(e_in.insn)) &
 		    "=" & to_hstring(c_in);
-		if ( is_fast_spr(e_in.write_reg) = '1' ) then
+		if is_fast_spr(e_in.write_reg) then
 		    result := c_in;
 		    result_en := '1';
 		    if decode_spr_num(e_in.insn) = SPR_XER then


### PR DESCRIPTION
Some vhdl 2008 features are not suported for simulation in vivado even recent version 2020. This batch fixes all the simulation errors.