### PR TITLE
Fully initialize FPU buses when FPU is disabled

### DIFF
--- a/common.vhdl
+++ b/common.vhdl
@@ -471,6 +471,7 @@ package common is
         interrupt : std_ulogic;
         illegal   : std_ulogic;
     end record;
+    constant FPUToExecute1Init : FPUToExecute1Type := (others => '0');
 
     type FPUToWritebackType is record
         valid           : std_ulogic;
@@ -481,6 +482,7 @@ package common is
         write_cr_mask   : std_ulogic_vector(7 downto 0);
         write_cr_data   : std_ulogic_vector(31 downto 0);
     end record;
+    constant FPUToWritebackInit : FPUToWritebackType :=  (valid => '0', write_enable => '0', write_cr_enable => '0', others => (others => '0'));
 
     type DividerToExecute1Type is record
 	valid: std_ulogic;

--- a/core.vhdl
+++ b/core.vhdl
@@ -350,13 +350,8 @@ begin
 
     no_fpu: if not HAS_FPU generate
     begin
-        fpu_to_execute1.busy <= '0';
-        fpu_to_execute1.exception <= '0';
-        fpu_to_execute1.interrupt <= '0';
-        fpu_to_execute1.illegal <= '0';
-        fpu_to_writeback.valid <= '0';
-        fpu_to_writeback.write_enable <= '0';
-        fpu_to_writeback.write_cr_enable <= '0';
+        fpu_to_execute1 <= FPUToExecute1Init;
+        fpu_to_writeback <= FPUToWritebackInit;
     end generate;
 
     loadstore1_0: entity work.loadstore1


### PR DESCRIPTION
Some of the bits in the FPU buses end up as z state. Yosys
flags them, so we may as well clean it up.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>