### PR TITLE
soc: Drive uart1_irq to 0 when we don't have UART1

### DIFF
--- a/icache.vhdl
+++ b/icache.vhdl
@@ -499,7 +499,7 @@ begin
         -- last cycle, and we don't want the first 32-bit chunk, then we can
         -- keep the data we read last cycle and just use that.
         if unsigned(i_in.nia(INSN_BITS+2-1 downto 2)) /= 0 then
-            use_previous <= i_in.sequential and r.hit_valid;
+            use_previous <= i_in.req and i_in.sequential and r.hit_valid;
         else
             use_previous <= '0';
         end if;

--- a/soc.vhdl
+++ b/soc.vhdl
@@ -754,6 +754,7 @@ begin
 	wb_uart1_out.dat <= x"00000000";
 	wb_uart1_out.ack <= wb_uart1_in.cyc and wb_uart1_in.stb;
 	wb_uart1_out.stall <= '0';
+        uart1_irq <= '0';
     end generate;
 
     spiflash_gen: if HAS_SPI_FLASH generate        


### PR DESCRIPTION
The tools complain about uart1_irq not being driven and not having a
default when HAS_UART1 is false.  This sets it to 0 in that case.

Fixes: 7575b1e0c2b1 ("uart: Import and hook up opencore 16550 compatible UART")
Signed-off-by: Paul Mackerras <paulus@ozlabs.org>