### PR TITLE
Reset TB and DECR

### DIFF
--- a/execute1.vhdl
+++ b/execute1.vhdl
@@ -282,6 +282,8 @@ begin
 	if rising_edge(clk) then
             if rst = '1' then
                 r <= reg_type_init;
+                ctrl.tb <= (others => '0');
+                ctrl.dec <= (others => '0');
                 ctrl.msr <= (MSR_SF => '1', MSR_LE => '1', others => '0');
                 ctrl.irq_state <= WRITE_SRR0;
             else


### PR DESCRIPTION
We don't care what the values of TB and DECR are after reset, but we
don't want the X state to propagate to other parts of the chip.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>