### PR TITLE
Reset cmd_ready_o in spi_txrx

### DIFF
--- a/spi_rxtx.vhdl
+++ b/spi_rxtx.vhdl
@@ -257,12 +257,16 @@ begin
     count_bit: process(clk)
     begin
         if rising_edge(clk) then
-            if start_cmd = '1' then
-                bit_count <= cmd_clks_i;
-            elsif state /= DATA then
-                bit_count <= (others => '1');
-            elsif sck_recv = '1' then
-                bit_count <= std_ulogic_vector(unsigned(bit_count) - 1);
+            if rst = '1' then
+                bit_count <= (others => '0');
+            else
+                if start_cmd = '1' then
+                    bit_count <= cmd_clks_i;
+                elsif state /= DATA then
+                    bit_count <= (others => '1');
+                elsif sck_recv = '1' then
+                    bit_count <= std_ulogic_vector(unsigned(bit_count) - 1);
+                end if;
             end if;
         end if;
     end process;


### PR DESCRIPTION
Initialize bit_count so that cmd_ready_o isn't X state immediately
after reset.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>