### PR TITLE
Fix another reset issue in spi_rxtx

### DIFF
--- a/spi_rxtx.vhdl
+++ b/spi_rxtx.vhdl
@@ -177,6 +177,7 @@ begin
                 sck_send <= '0';
                 sck_recv <= '0';
                 clk_div  <= 0;
+                counter := 0;
             elsif counter = clk_div then
                 counter := 0;
 


### PR DESCRIPTION
counter was X state after reset, initialize it.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>