### PR TITLE
Add a test to read from all SPRs

### DIFF
--- a/tests/spr_read/Makefile
+++ b/tests/spr_read/Makefile
@@ -1,0 +1,3 @@
+TEST=spr_read
+
+include ../Makefile.test

--- a/tests/spr_read/head.S
+++ b/tests/spr_read/head.S
@@ -1,0 +1,46 @@
+/* Copyright 2013-2014 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define STACK_TOP 0x2000
+
+/* Load an immediate 64-bit value into a register */
+#define LOAD_IMM64(r, e)			\
+	lis	r,(e)@highest;			\
+	ori	r,r,(e)@higher;			\
+	rldicr	r,r, 32, 31;			\
+	oris	r,r, (e)@h;			\
+	ori	r,r, (e)@l;
+
+	.section ".head","ax"
+
+	/*
+	 * Microwatt currently enters in LE mode at 0x0, so we don't need to
+	 * do any endian fix ups
+	 */
+	. = 0
+.global _start
+_start:
+	b	boot_entry
+
+.global boot_entry
+boot_entry:
+	/* setup stack */
+	LOAD_IMM64(%r1, STACK_TOP - 0x100)
+	LOAD_IMM64(%r12, main)
+	mtctr	%r12
+	bctrl
+	attn // terminate on exit
+	b .

--- a/tests/spr_read/powerpc.lds
+++ b/tests/spr_read/powerpc.lds
@@ -1,0 +1,13 @@
+SECTIONS
+{
+	_start = .;
+	. = 0;
+	.head : {
+		KEEP(*(.head))
+ 	}
+	. = 0x1000;
+	.text : { *(.text) }
+	. = 0x2000;
+	.data : { *(.data) }
+	.bss : { *(.bss) }
+}

--- a/tests/spr_read/spr_read.c
+++ b/tests/spr_read/spr_read.c
@@ -1,0 +1,92 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "console.h"
+
+#define TEST "Test "
+#define PASS "PASS\n"
+#define FAIL "FAIL\n"
+
+// i < 100
+void print_test(char *str)
+{
+	puts(TEST);
+	puts(str);
+	putchar(':');
+}
+
+#define SPR_XER		1
+#define SPR_LR		8
+#define SPR_CTR		9
+#define SPR_TAR		815
+#define SPR_DSISR	18
+#define SPR_DAR		19
+#define SPR_TB		268
+#define SPR_TBU		269
+#define SPR_DEC		22
+#define SPR_SRR0	26
+#define SPR_SRR1	27
+#define SPR_CFAR	28
+#define SPR_HSRR0	314
+#define SPR_HSRR1	315
+#define SPR_SPRG0	272
+#define SPR_SPRG1	273
+#define SPR_SPRG2	274
+#define SPR_SPRG3	275
+#define SPR_SPRG3U	259
+#define SPR_HSPRG0	304
+#define SPR_HSPRG1	305
+#define SPR_PID		48
+#define SPR_PRTBL	720
+#define SPR_PVR		287
+
+#define __stringify_1(x...)	#x
+#define __stringify(x...)	__stringify_1(x)
+
+int main(void)
+{
+	unsigned long tmp;
+
+	console_init();
+
+	/*
+	 * Read all SPRs. Rely on the register file raising an assertion if we
+	 * write X state to a GPR.
+	 */
+
+#define DO_ONE(SPR) { \
+		print_test(#SPR); \
+		__asm__ __volatile__("mfspr %0," __stringify(SPR) : "=r" (tmp)); \
+		puts(PASS); \
+	}
+
+	DO_ONE(SPR_XER);
+	DO_ONE(SPR_LR);
+	DO_ONE(SPR_CTR);
+	DO_ONE(SPR_TAR);
+	DO_ONE(SPR_DSISR);
+	DO_ONE(SPR_DAR);
+	DO_ONE(SPR_TB);
+	DO_ONE(SPR_TBU);
+	DO_ONE(SPR_DEC);
+	DO_ONE(SPR_SRR0);
+	DO_ONE(SPR_SRR1);
+	DO_ONE(SPR_CFAR);
+	DO_ONE(SPR_HSRR0);
+	DO_ONE(SPR_HSRR1);
+	DO_ONE(SPR_SPRG0);
+	DO_ONE(SPR_SPRG1);
+	DO_ONE(SPR_SPRG2);
+	DO_ONE(SPR_SPRG3);
+	DO_ONE(SPR_SPRG3U);
+	DO_ONE(SPR_HSPRG0);
+	DO_ONE(SPR_HSPRG1);
+	DO_ONE(SPR_PID);
+	DO_ONE(SPR_PRTBL);
+	DO_ONE(SPR_PVR);
+
+	puts(PASS);
+
+	return 0;
+}

--- a/tests/update_console_tests
+++ b/tests/update_console_tests
@@ -3,7 +3,7 @@
 # Script to update console related tests from source
 #
 
-for i in sc illegal decrementer xics privileged mmu misc modes reservation trace fpu ; do
+for i in sc illegal decrementer xics privileged mmu misc modes reservation trace fpu spr_read; do
     cd $i
     make
     cd -


### PR DESCRIPTION
Make sure the SPRs are initialized and we can't read X state.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>