### PR TITLE
This commit adds a fusesoc core file for the uart16550 component.

### DIFF
--- a/uart16550/uart16550.core
+++ b/uart16550/uart16550.core
@@ -1,0 +1,17 @@
+CAPI=2:
+
+name : ::uart16550
+
+filesets:
+  core:
+    files:
+    - raminfr.v
+    - uart_defines.v
+    - uart_receiver.v
+    - uart_regs.v
+    - uart_rfifo.v
+    - uart_sync_flops.v
+    - uart_tfifo.v
+    - uart_top.v
+    - uart_transmitter.v
+    - uart_wb.v

--- a/uart16550/uart16550.core
+++ b/uart16550/uart16550.core
@@ -5,13 +5,16 @@ name : ::uart16550
 filesets:
   core:
     files:
-    - raminfr.v
-    - uart_defines.v
-    - uart_receiver.v
-    - uart_regs.v
-    - uart_rfifo.v
-    - uart_sync_flops.v
-    - uart_tfifo.v
-    - uart_top.v
-    - uart_transmitter.v
-    - uart_wb.v
+    - raminfr.v : { filetype = "verilog" }
+    - uart_regs.v : { filetype = "verilog" }
+    - uart_rfifo.v : { filetype = "verilog" }
+    - uart_sync_flops.v : { filetype = "verilog" }
+    - uart_tfifo.v : { filetype = "verilog" }
+    - uart_transmitter.v : { filetype = "verilog" }
+    - uart_wb.v : { filetype = "verilog" }
+  uart_receiver:
+    files:
+    - uart_receiver.v : { filetype = "verilog" }
+  uart_top:
+    files:
+    - uart_wb.v : { filetype = "verilog" }


### PR DESCRIPTION
I'm experiencing the same issue as mentioned in #230 - fusesoc does not find the uart16550 core when building for xilinx arty targets.

This commit adds a core file as referenced by microwatt.core to satisfy that dependency. Fusesoc is then able to synthesize the project via Vivado.