### PR TITLE
Update documentation to reference fusesoc init, add link to Digilent board files

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ sudo dnf copr enable sharkcz/danny
 sudo dnf install fusesoc
 ```
 
+- If this is your first time using fusesoc, initialize fusesoc. 
+  This is needed to be able to pull down fussoc library components referenced 
+  by microwatt. Run
+
+```
+fusesoc init
+```
+
 - Create a working directory and point FuseSoC at microwatt:
 
 ```
@@ -106,6 +114,8 @@ fusesoc library add microwatt /path/to/microwatt/
 ```
 
 - Build using FuseSoC. For hello world (Replace nexys_video with your FPGA board such as --target=arty_a7-100):
+  You may wish to ensure you have [installed Digilent Board files](https://reference.digilentinc.com/vivado/installing-vivado/start#installing_digilent_board_files) 
+  or appropriate files for your board first.
 
 ```
 fusesoc run --target=nexys_video microwatt --memory_size=16384 --ram_init_file=/path/to/microwatt/fpga/hello_world.hex


### PR DESCRIPTION
Unfortunately some people like myself are not very knowledgeable about the world of FPGAs. My previous issue was caused by a simple matter of not having run `fusesoc init`. This commit adds that comment to the readme. Similarly, since digilent provide board files for all their boards, including the arty-a7 referenced in the readme, I have also added a link to the installation guide for these files.

I hope this helps, thanks for the great project!