### PR TITLE
Pass icache/dcache/tlb parameters down from soc

### DIFF
--- a/core.vhdl
+++ b/core.vhdl
@@ -14,7 +14,14 @@ entity core is
         HAS_FPU : boolean := true;
         HAS_BTC : boolean := true;
 	ALT_RESET_ADDRESS : std_ulogic_vector(63 downto 0) := (others => '0');
-        LOG_LENGTH : natural := 512
+        LOG_LENGTH : natural := 512;
+        ICACHE_NUM_LINES : natural := 64;
+        ICACHE_NUM_WAYS : natural := 2;
+        ICACHE_TLB_SIZE : natural := 64;
+        DCACHE_NUM_LINES : natural := 64;
+        DCACHE_NUM_WAYS : natural := 2;
+        DCACHE_TLB_SET_SIZE : natural := 64;
+        DCACHE_TLB_NUM_WAYS : natural := 2
         );
     port (
         clk          : in std_ulogic;
@@ -217,8 +224,9 @@ begin
         generic map(
             SIM => SIM,
             LINE_SIZE => 64,
-            NUM_LINES => 64,
-	    NUM_WAYS => 2,
+            NUM_LINES => ICACHE_NUM_LINES,
+            NUM_WAYS => ICACHE_NUM_WAYS,
+            TLB_SIZE => ICACHE_TLB_SIZE,
             LOG_LENGTH => LOG_LENGTH
             )
         port map(
@@ -399,8 +407,10 @@ begin
     dcache_0: entity work.dcache
         generic map(
             LINE_SIZE => 64,
-            NUM_LINES => 64,
-	    NUM_WAYS => 2,
+            NUM_LINES => DCACHE_NUM_LINES,
+            NUM_WAYS => DCACHE_NUM_WAYS,
+            TLB_SET_SIZE => DCACHE_TLB_SET_SIZE,
+            TLB_NUM_WAYS => DCACHE_TLB_NUM_WAYS,
             LOG_LENGTH => LOG_LENGTH
             )
         port map (

--- a/soc.vhdl
+++ b/soc.vhdl
@@ -66,7 +66,14 @@ entity soc is
         LOG_LENGTH         : natural := 512;
         HAS_LITEETH        : boolean := false;
 	UART0_IS_16550     : boolean := true;
-	HAS_UART1          : boolean := false
+	HAS_UART1          : boolean := false;
+        ICACHE_NUM_LINES   : natural := 64;
+        ICACHE_NUM_WAYS    : natural := 2;
+        ICACHE_TLB_SIZE    : natural := 64;
+        DCACHE_NUM_LINES   : natural := 64;
+        DCACHE_NUM_WAYS    : natural := 2;
+        DCACHE_TLB_SET_SIZE : natural := 64;
+        DCACHE_TLB_NUM_WAYS : natural := 2
 	);
     port(
 	rst          : in  std_ulogic;
@@ -259,7 +266,14 @@ begin
             HAS_BTC => HAS_BTC,
 	    DISABLE_FLATTEN => DISABLE_FLATTEN_CORE,
 	    ALT_RESET_ADDRESS => (23 downto 0 => '0', others => '1'),
-            LOG_LENGTH => LOG_LENGTH
+            LOG_LENGTH => LOG_LENGTH,
+            ICACHE_NUM_LINES => ICACHE_NUM_LINES,
+            ICACHE_NUM_WAYS => ICACHE_NUM_WAYS,
+            ICACHE_TLB_SIZE => ICACHE_TLB_SIZE,
+            DCACHE_NUM_LINES => DCACHE_NUM_LINES,
+            DCACHE_NUM_WAYS => DCACHE_NUM_WAYS,
+            DCACHE_TLB_SET_SIZE => DCACHE_TLB_SET_SIZE,
+            DCACHE_TLB_NUM_WAYS => DCACHE_TLB_NUM_WAYS
 	    )
 	port map(
 	    clk => system_clk,


### PR DESCRIPTION
We want much smaller caches and tlbs when building for sky130, so
allow the toplevel file to override the defaults.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>