### PR TITLE
Allow SPI BOOT_CLOCKS to be overridden by top level

### DIFF
--- a/soc.vhdl
+++ b/soc.vhdl
@@ -63,6 +63,7 @@ entity soc is
         SPI_FLASH_OFFSET   : integer := 0;
         SPI_FLASH_DEF_CKDV : natural := 2;
         SPI_FLASH_DEF_QUAD : boolean := false;
+        SPI_BOOT_CLOCKS    : boolean := true;
         LOG_LENGTH         : natural := 512;
         HAS_LITEETH        : boolean := false;
 	UART0_IS_16550     : boolean := true;
@@ -764,7 +765,8 @@ begin
             generic map (
                 DATA_LINES    => SPI_FLASH_DLINES,
                 DEF_CLK_DIV   => SPI_FLASH_DEF_CKDV,
-                DEF_QUAD_READ => SPI_FLASH_DEF_QUAD
+                DEF_QUAD_READ => SPI_FLASH_DEF_QUAD,
+                BOOT_CLOCKS   => SPI_BOOT_CLOCKS
                 )
             port map(
                 rst => rst_spi,


### PR DESCRIPTION
Our SPI controller sends 8 dummy clocks at boot which Ben
added for some Xilinx boards. This should be harmless but
it is confusing the flash testbench in the Caravel project.

Add a parameter so it can be overridden at the top level.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>