### PR TITLE
VUnit cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
   schedule:
     - cron: '0 0 * * 5'
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,10 +54,11 @@ jobs:
   VUnit:
     needs: [build]
     runs-on: ubuntu-latest
-    container: ghdl/vunit:llvm
     steps:
     - uses: actions/checkout@v2
-    - run: python3 ./run.py -p10
+    - uses: docker://ghdl/vunit:llvm
+      with:
+        args: python3 ./run.py -p10
 
   symbiflow:
     strategy:

--- a/run.py
+++ b/run.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from vunit import VUnit
-from glob import glob
 
 prj = VUnit.from_argv()
 prj.add_osvvm()
@@ -11,7 +10,7 @@ lib.add_source_files(root / "litedram" / "extras" / "*.vhdl")
 lib.add_source_files(root / "litedram" / "generated" / "sim" / "*.vhdl")
 
 # Use multiply.vhd and not xilinx-mult.vhd. Use VHDL-based random.
-vhdl_files = glob(str(root / "*.vhdl"))
+vhdl_files = root.glob("*.vhdl")
 vhdl_files = [
     src_file
     for src_file in vhdl_files

--- a/run.py
+++ b/run.py
@@ -1,28 +1,23 @@
 from pathlib import Path
 from vunit import VUnit
 
-prj = VUnit.from_argv()
-prj.add_osvvm()
-root = Path(__file__).parent
+ROOT = Path(__file__).parent
 
-lib = prj.add_library("lib")
-lib.add_source_files(root / "litedram" / "extras" / "*.vhdl")
-lib.add_source_files(root / "litedram" / "generated" / "sim" / "*.vhdl")
+PRJ = VUnit.from_argv()
+PRJ.add_osvvm()
 
-# Use multiply.vhd and not xilinx-mult.vhd. Use VHDL-based random.
-vhdl_files = root.glob("*.vhdl")
-vhdl_files = [
+PRJ.add_library("lib").add_source_files([
+    ROOT / "litedram" / "extras" / "*.vhdl",
+    ROOT / "litedram" / "generated" / "sim" / "*.vhdl"
+] + [
     src_file
-    for src_file in vhdl_files
-    if ("xilinx-mult" not in src_file)
-    and ("foreign_random" not in src_file)
-    and ("nonrandom" not in src_file)
-]
-lib.add_source_files(vhdl_files)
+    for src_file in ROOT.glob("*.vhdl")
+    # Use multiply.vhd and not xilinx-mult.vhd. Use VHDL-based random.
+    if not any(exclude in str(src_file) for exclude in ["xilinx-mult", "foreign_random", "nonrandom"])
+])
 
-unisim = prj.add_library("unisim")
-unisim.add_source_files(root / "sim-unisim" / "*.vhdl")
+PRJ.add_library("unisim").add_source_files(ROOT / "sim-unisim" / "*.vhdl")
 
-prj.set_sim_option("disable_ieee_warnings", True)
+PRJ.set_sim_option("disable_ieee_warnings", True)
 
-prj.main()
+PRJ.main()


### PR DESCRIPTION
This PR contributes some minor tweaks to the VUnit plumbing:

- Instead of using a container job, use a regular job and execute only the VUnit step in a container. The difference is that `actions/checkout` is executed on the host (where git exists) instead of inside the container (without git). The Action falls back to using the REST API for cloning the repo when git is not found (see https://github.com/antonblanchard/microwatt/runs/3082251942?check_suite_focus=true#step:3:16). However, that is undesirable.
- Event `workflow_dispatch` is added to allow triggering the workflow manually (either graphically through the web or using the API).
- Instead of using `glob.glob` in the VUnit `run.py` script, `Path.glob` is used.
- Some style changes are applied to `run.py` in order to slightly reduce the verbosity.

/cc @LarsAsplund 