### PR TITLE
Reduce the size of icache to help yosys ECP5 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,10 @@ RAM_INIT_FILE=hello_world/hello_world.hex
 
 FPGA_TARGET ?= ORANGE-CRAB
 
+# FIXME: icache RAMs aren't being inferrenced as block RAMs on ECP5
+# with yosys, so make it smaller for now as a workaround.
+ICACHE_NUM_LINES=4
+
 # OrangeCrab with ECP85
 ifeq ($(FPGA_TARGET), ORANGE-CRAB)
 RESET_LOW=true
@@ -168,7 +172,7 @@ OPENOCD_DEVICE_CONFIG=openocd/LFE5UM5G-85F.cfg
 endif
 
 GHDL_IMAGE_GENERICS=-gMEMORY_SIZE=$(MEMORY_SIZE) -gRAM_INIT_FILE=$(RAM_INIT_FILE) \
-	-gRESET_LOW=$(RESET_LOW) -gCLK_INPUT=$(CLK_INPUT) -gCLK_FREQUENCY=$(CLK_FREQUENCY)
+	-gRESET_LOW=$(RESET_LOW) -gCLK_INPUT=$(CLK_INPUT) -gCLK_FREQUENCY=$(CLK_FREQUENCY) -gICACHE_NUM_LINES=$(ICACHE_NUM_LINES)
 
 clkgen=fpga/clk_gen_ecp5.vhd
 toplevel=fpga/top-generic.vhdl

--- a/fpga/top-generic.vhdl
+++ b/fpga/top-generic.vhdl
@@ -13,6 +13,7 @@ entity toplevel is
 	CLK_FREQUENCY : positive := 100000000;
         HAS_FPU       : boolean  := true;
         HAS_BTC       : boolean  := false;
+        ICACHE_NUM_LINES : natural := 64;
         LOG_LENGTH    : natural := 512;
 	DISABLE_FLATTEN_CORE : boolean := false;
         UART_IS_16550 : boolean  := true
@@ -73,6 +74,7 @@ begin
 	    CLK_FREQ      => CLK_FREQUENCY,
             HAS_FPU       => HAS_FPU,
             HAS_BTC       => HAS_BTC,
+	    ICACHE_NUM_LINES => ICACHE_NUM_LINES,
             LOG_LENGTH    => LOG_LENGTH,
 	    DISABLE_FLATTEN_CORE => DISABLE_FLATTEN_CORE,
             UART0_IS_16550     => UART_IS_16550


### PR DESCRIPTION
The icache RAM is currently LUT ram not block ram. This massively
bloats the icache size. We think this is due to yosys not inferencing
the RAM correctly but that's yet to be confirmed.

Work around this for now by reducing the default size of the icache
RAM for the ECP5 builds.

On the ECP5 85K builts, this gets us from 95% down to 76% and helps
our CI to pass.