### PR TITLE
ci: test 'build' with LLVM and GCC backends

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,13 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    container: ghdl/vunit:llvm
+    strategy:
+      fail-fast: false
+      matrix:
+        backend:
+        - llvm
+        - gcc
+    container: ghdl/vunit:${{ matrix.backend }}
     steps:
     - uses: actions/checkout@v2
     - run: make GNATMAKE='gnatmake -j'$(nproc)


### PR DESCRIPTION
GHDL supports three different backends (mcode, LLVM and GCC). In this project, LLVM is used only. Due to how the Makefile is written, it's not possible to use mcode at the moment. However, GCC can be used.

This PR adds a matrix in job `build` in order to test both LLVM and GCC backends. That allows to catch regressions/inconsistencies between backends. At the same time, GCC provides some unique features, most notably code coverage through gcov. Therefore, it might be interesting to extend CI with that in the future.