### PR TITLE
ci: Remove noflatten to reduce size of ECP5 builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER: 1
-      SYNTH_ECP5_FLAGS: -noflatten
       FPGA_TARGET: ${{matrix.task}}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This option was added in the commit but is no longer needed for github
CI to work.

    commit ef0dcf3bc6380cd6c3454cac7ff881a7454a8281
    Author: Michael Neuling <mikey@neuling.org>
    Date:   Thu Jul 2 14:36:14 2020 +1000
    Add SYNTH_ECP5_FLAGS option for building

Removing noflatten has the added advantage that it gets our builds
from 75% down to 59% usage on ECP5 85K.