### PR TITLE
Small cleanups to clock definitions

### DIFF
--- a/fpga/arty_a7.xdc
+++ b/fpga/arty_a7.xdc
@@ -531,7 +531,7 @@ set_property CONFIG_MODE SPIx4 [current_design]
 # Clock constraints
 ################################################################################
 
-create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports { ext_clk }];
+create_clock -add -name sys_clk_pin -period 10.00 [get_ports { ext_clk }];
 
 create_clock -name eth_rx_clk -period 40.0 [get_ports { eth_clocks_rx }]
 

--- a/fpga/arty_a7.xdc
+++ b/fpga/arty_a7.xdc
@@ -531,7 +531,7 @@ set_property CONFIG_MODE SPIx4 [current_design]
 # Clock constraints
 ################################################################################
 
-create_clock -add -name sys_clk_pin -period 10.00 [get_ports { ext_clk }];
+create_clock -name sys_clk_pin -period 10.00 [get_ports { ext_clk }];
 
 create_clock -name eth_rx_clk -period 40.0 [get_ports { eth_clocks_rx }]
 

--- a/fpga/cmod_a7-35.xdc
+++ b/fpga/cmod_a7-35.xdc
@@ -1,6 +1,6 @@
 ## Clock signal 12 MHz
 set_property -dict { PACKAGE_PIN L17   IOSTANDARD LVCMOS33 } [get_ports { ext_clk }];
-create_clock -add -name sys_clk_pin -period 83.33 [get_ports {ext_clk}];
+create_clock -name sys_clk_pin -period 83.33 [get_ports {ext_clk}];
 
 set_property -dict { PACKAGE_PIN J18   IOSTANDARD LVCMOS33 } [get_ports { uart0_txd }];
 set_property -dict { PACKAGE_PIN J17   IOSTANDARD LVCMOS33 } [get_ports { uart0_rxd  }];

--- a/fpga/cmod_a7-35.xdc
+++ b/fpga/cmod_a7-35.xdc
@@ -1,6 +1,6 @@
 ## Clock signal 12 MHz
 set_property -dict { PACKAGE_PIN L17   IOSTANDARD LVCMOS33 } [get_ports { ext_clk }];
-create_clock -add -name sys_clk_pin -period 83.33 -waveform {0 41.66} [get_ports {ext_clk}];
+create_clock -add -name sys_clk_pin -period 83.33 [get_ports {ext_clk}];
 
 set_property -dict { PACKAGE_PIN J18   IOSTANDARD LVCMOS33 } [get_ports { uart0_txd }];
 set_property -dict { PACKAGE_PIN J17   IOSTANDARD LVCMOS33 } [get_ports { uart0_rxd  }];

--- a/fpga/genesys2.xdc
+++ b/fpga/genesys2.xdc
@@ -3,8 +3,8 @@
 ## Clock & Reset
 set_property -dict { PACKAGE_PIN AD11  IOSTANDARD LVDS     } [get_ports { clk200_n }]
 set_property -dict { PACKAGE_PIN AD12  IOSTANDARD LVDS     } [get_ports { clk200_p }]
-create_clock -period 5.000 -name tc_clk100_p -waveform {0.000 2.500} [get_ports clk200_p]
-create_clock -period 5.000 -name tc_clk100_n -waveform {2.500 5.000} [get_ports clk200_n]
+create_clock -period 5.000 -name tc_clk100_p [get_ports clk200_p]
+create_clock -period 5.000 -name tc_clk100_n [get_ports clk200_n]
 
 set_property -dict { PACKAGE_PIN R19   IOSTANDARD LVCMOS33 } [get_ports { ext_rst }]
 

--- a/fpga/nexys-video.xdc
+++ b/fpga/nexys-video.xdc
@@ -313,7 +313,7 @@ set_property CONFIG_MODE SPIx4 [current_design]
 # Clock constraints
 ################################################################################
 
-create_clock -add -name sys_clk_pin -period 10.00 [get_ports { ext_clk }];
+create_clock -name sys_clk_pin -period 10.00 [get_ports { ext_clk }];
 
 ################################################################################
 # False path constraints (from LiteX as they relate to LiteDRAM)

--- a/fpga/nexys-video.xdc
+++ b/fpga/nexys-video.xdc
@@ -313,7 +313,7 @@ set_property CONFIG_MODE SPIx4 [current_design]
 # Clock constraints
 ################################################################################
 
-create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports { ext_clk }];
+create_clock -add -name sys_clk_pin -period 10.00 [get_ports { ext_clk }];
 
 ################################################################################
 # False path constraints (from LiteX as they relate to LiteDRAM)

--- a/fpga/nexys_a7.xdc
+++ b/fpga/nexys_a7.xdc
@@ -1,5 +1,5 @@
 set_property -dict {PACKAGE_PIN E3 IOSTANDARD LVCMOS33} [get_ports ext_clk]
-create_clock -period 10.000 -name sys_clk_pin -waveform {0.000 5.000} -add [get_ports ext_clk]
+create_clock -period 10.000 -name sys_clk_pin -add [get_ports ext_clk]
 
 set_property -dict {PACKAGE_PIN C12 IOSTANDARD LVCMOS33} [get_ports ext_rst]
 

--- a/fpga/nexys_a7.xdc
+++ b/fpga/nexys_a7.xdc
@@ -1,5 +1,5 @@
 set_property -dict {PACKAGE_PIN E3 IOSTANDARD LVCMOS33} [get_ports ext_clk]
-create_clock -period 10.000 -name sys_clk_pin -add [get_ports ext_clk]
+create_clock -period 10.000 -name sys_clk_pin [get_ports ext_clk]
 
 set_property -dict {PACKAGE_PIN C12 IOSTANDARD LVCMOS33} [get_ports ext_rst]
 


### PR DESCRIPTION
We shouldn't need either -waveform or -add options to the create_clock command, so remove
both options.