### PR TITLE
Rename 'do' signal to avoid verilator System Verilog warning

### DIFF
--- a/fpga/main_bram.vhdl
+++ b/fpga/main_bram.vhdl
@@ -17,8 +17,8 @@ entity main_bram is
     port(
         clk  : in std_logic;
         addr : in std_logic_vector(HEIGHT_BITS - 1 downto 0) ;
-        di   : in std_logic_vector(WIDTH-1 downto 0);
-        do   : out std_logic_vector(WIDTH-1 downto 0);
+        din  : in std_logic_vector(WIDTH-1 downto 0);
+        dout : out std_logic_vector(WIDTH-1 downto 0);
         sel  : in std_logic_vector((WIDTH/8)-1 downto 0);
         re   : in std_ulogic;
         we   : in std_ulogic
@@ -68,14 +68,14 @@ begin
                 for i in 0 to 7 loop
                     if sel(i) = '1' then
                         memory(to_integer(unsigned(addr)))((i + 1) * 8 - 1 downto i * 8) <=
-                            di((i + 1) * 8 - 1 downto i * 8);
+                            din((i + 1) * 8 - 1 downto i * 8);
                     end if;
                 end loop;
             end if;
             if re = '1' then
                 obuf <= memory(to_integer(unsigned(addr)));
             end if;
-            do <= obuf;
+            dout <= obuf;
         end if;
     end process;
 

--- a/sim_bram.vhdl
+++ b/sim_bram.vhdl
@@ -21,8 +21,8 @@ entity main_bram is
     port(
         clk  : in std_logic;
         addr : in std_logic_vector(HEIGHT_BITS - 1 downto 0) ;
-        di   : in std_logic_vector(WIDTH-1 downto 0);
-        do   : out std_logic_vector(WIDTH-1 downto 0);
+        din  : in std_logic_vector(WIDTH-1 downto 0);
+        dout : out std_logic_vector(WIDTH-1 downto 0);
         sel  : in std_logic_vector((WIDTH/8)-1 downto 0);
         re   : in std_ulogic;
         we   : in std_ulogic
@@ -50,9 +50,9 @@ begin
             addr64 := (others => '0');
             addr64(HEIGHT_BITS + 2 downto 3) := addr;
             if we = '1' then        
-                report "RAM writing " & to_hstring(di) & " to " &
+                report "RAM writing " & to_hstring(din) & " to " &
                     to_hstring(addr & pad_zeros) & " sel:" & to_hstring(sel);
-                behavioural_write(di, addr64, to_integer(unsigned(sel)), identifier);
+                behavioural_write(din, addr64, to_integer(unsigned(sel)), identifier);
             end if;
             if re = '1' then
                 behavioural_read(ret_dat_v, addr64, to_integer(unsigned(sel)), identifier);
@@ -60,7 +60,7 @@ begin
                     " returns " & to_hstring(ret_dat_v);
                 obuf <= ret_dat_v(obuf'left downto 0);
             end if;
-            do <= obuf;
+            dout <= obuf;
         end if;
     end process;
 

--- a/wishbone_bram_wrapper.vhdl
+++ b/wishbone_bram_wrapper.vhdl
@@ -46,8 +46,8 @@ begin
 	port map(
 	    clk => clk,
 	    addr => ram_addr,
-	    di => wishbone_in.dat,
-	    do => wishbone_out.dat,
+	    din  => wishbone_in.dat,
+	    dout => wishbone_out.dat,
 	    sel => wishbone_in.sel,
 	    re => ram_re,
 	    we => ram_we


### PR DESCRIPTION
Experimenting with using ghdl to do VHDL to Verilog conversion (instead
of ghdl+yosys), verilator complains that a signal is a SystemVerilog
keyword:

%Error: microwatt.v:15013:18: Unexpected 'do': 'do' is a SystemVerilog keyword misused as an identifier.
        ... Suggest modify the Verilog-2001 code to avoid SV keywords, or use `begin_keywords or --language.

We could probably make this go away by disabling SystemVerilog, but
it's easy to rename the signal in question. Rename di at the same
time.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>