### PR TITLE
gpio: Add HAS_GPIO to avoid verilator build errors

### DIFF
--- a/fpga/top-arty.vhdl
+++ b/fpga/top-arty.vhdl
@@ -28,6 +28,7 @@ entity toplevel is
         UART_IS_16550      : boolean  := false;
         HAS_UART1          : boolean  := true;
         USE_LITESDCARD     : boolean := false;
+        HAS_GPIO           : boolean := true;
         NGPIO              : natural := 32
         );
     port(
@@ -207,6 +208,7 @@ begin
             UART0_IS_16550     => UART_IS_16550,
             HAS_UART1          => HAS_UART1,
             HAS_SD_CARD        => USE_LITESDCARD,
+            HAS_GPIO           => HAS_GPIO,
             NGPIO              => NGPIO
             )
         port map (

--- a/soc.vhdl
+++ b/soc.vhdl
@@ -81,7 +81,8 @@ entity soc is
         DCACHE_TLB_SET_SIZE : natural := 64;
         DCACHE_TLB_NUM_WAYS : natural := 2;
         HAS_SD_CARD        : boolean := false;
-        NGPIO              : natural := 0
+        HAS_GPIO           : boolean := false;
+        NGPIO              : natural := 32
 	);
     port(
 	rst          : in  std_ulogic;
@@ -913,20 +914,22 @@ begin
             icp_out => ics_to_icp
 	    );
 
-    gpio : entity work.gpio
-        generic map(
-            NGPIO => NGPIO
-            )
-        port map(
-            clk      => system_clk,
-            rst      => rst_gpio,
-            wb_in    => wb_gpio_in,
-            wb_out   => wb_gpio_out,
-            gpio_in  => gpio_in,
-            gpio_out => gpio_out,
-            gpio_dir => gpio_dir,
-            intr     => gpio_intr
-            );
+    gpio0_gen: if HAS_GPIO generate
+        gpio : entity work.gpio
+            generic map(
+                NGPIO => NGPIO
+                )
+            port map(
+                clk      => system_clk,
+                rst      => rst_gpio,
+                wb_in    => wb_gpio_in,
+                wb_out   => wb_gpio_out,
+                gpio_in  => gpio_in,
+                gpio_out => gpio_out,
+                gpio_dir => gpio_dir,
+                intr     => gpio_intr
+                );
+    end generate;
 
     -- Assign external interrupts
     interrupts: process(all)


### PR DESCRIPTION
The verilator build fails with warnings and errors, because NGPIO
is 0 and we do things like:

        gpio_out : out std_ulogic_vector(NGPIO - 1 downto 0);

Set NGPIO to something reasonable (eg 32) and add HAS_GPIO to avoid
building the macro entirely if it isn't in use.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>