### PR TITLE
Performance and timing improvements

### DIFF
--- a/common.vhdl
+++ b/common.vhdl
@@ -196,6 +196,7 @@ package common is
 	stop_mark: std_ulogic;
         sequential: std_ulogic;
         predicted : std_ulogic;
+        pred_ntaken : std_ulogic;
 	nia: std_ulogic_vector(63 downto 0);
     end record;
 
@@ -207,6 +208,7 @@ package common is
 	insn: std_ulogic_vector(31 downto 0);
         big_endian: std_ulogic;
         next_predicted: std_ulogic;
+        next_pred_ntaken: std_ulogic;
     end record;
 
     type IcacheEventType is record

--- a/decode1.vhdl
+++ b/decode1.vhdl
@@ -740,6 +740,8 @@ begin
         bv.br_offset := br_offset;
         if f_in.next_predicted = '1' then
             v.br_pred := '1';
+        elsif f_in.next_pred_ntaken = '1' then
+            v.br_pred := '0';
         end if;
         bv.predict := v.br_pred and f_in.valid and not flush_in and not busy_out and not f_in.next_predicted;
         -- after a clock edge...

--- a/icache.vhdl
+++ b/icache.vhdl
@@ -577,6 +577,7 @@ begin
         i_out.fetch_failed <= r.fetch_failed;
         i_out.big_endian <= r.big_endian;
         i_out.next_predicted <= i_in.predicted;
+        i_out.next_pred_ntaken <= i_in.pred_ntaken;
 
 	-- Stall fetch1 if we have a miss on cache or TLB or a protection fault
 	stall_out <= not (is_hit and access_ok);

--- a/xilinx-mult.vhdl
+++ b/xilinx-mult.vhdl
@@ -24,7 +24,6 @@ architecture behaviour of multiply is
     signal m11_pc, m12_pc, m13_pc : std_ulogic_vector(47 downto 0);
     signal m20_p, m21_p, m22_p, m23_p : std_ulogic_vector(47 downto 0);
     signal s0_pc, s1_pc : std_ulogic_vector(47 downto 0);
-    signal product_lo : std_ulogic_vector(31 downto 0);
     signal product : std_ulogic_vector(127 downto 0);
     signal addend : std_ulogic_vector(127 downto 0);
     signal s0_carry, p0_carry : std_ulogic_vector(3 downto 0);
@@ -33,7 +32,7 @@ architecture behaviour of multiply is
     signal p1_pat, p1_patb : std_ulogic;
 
     signal req_32bit, r32_1 : std_ulogic;
-    signal req_not, rnot_1 : std_ulogic;
+    signal rnot_1 : std_ulogic;
     signal valid_1 : std_ulogic;
     signal overflow, ovf_in : std_ulogic;
 
@@ -49,9 +48,11 @@ begin
             BREG => 0,
             CARRYINREG => 0,
             CARRYINSELREG => 0,
+            CREG => 0,
             INMODEREG => 0,
+            MREG => 0,
             OPMODEREG => 0,
-            PREG => 0
+            PREG => 1
             )
         port map (
             A => "0000000" & m_in.data1(22 downto 0),
@@ -69,13 +70,13 @@ begin
             CEALUMODE => '0',
             CEB1 => '0',
             CEB2 => '0',
-            CEC => '1',
+            CEC => '0',
             CECARRYIN => '0',
             CECTRL => '0',
             CED => '0',
             CEINMODE => '0',
-            CEM => m_in.valid,
-            CEP => '0',
+            CEM => '0',
+            CEP => m_in.valid,
             CLK => clk,
             D => (others => '0'),
             INMODE => "00000",
@@ -160,9 +161,11 @@ begin
             BREG => 0,
             CARRYINREG => 0,
             CARRYINSELREG => 0,
+            CREG => 0,
             INMODEREG => 0,
+            MREG => 0,
             OPMODEREG => 0,
-            PREG => 0
+            PREG => 1
             )
         port map (
             A => "0000000" & m_in.data1(22 downto 0),
@@ -180,13 +183,13 @@ begin
             CEALUMODE => '0',
             CEB1 => '0',
             CEB2 => '0',
-            CEC => '1',
+            CEC => '0',
             CECARRYIN => '0',
             CECTRL => '0',
             CED => '0',
             CEINMODE => '0',
-            CEM => m_in.valid,
-            CEP => '0',
+            CEM => '0',
+            CEP => m_in.valid,
             CLK => clk,
             D => (others => '0'),
             INMODE => "00000",
@@ -215,9 +218,11 @@ begin
             BREG => 0,
             CARRYINREG => 0,
             CARRYINSELREG => 0,
+            CREG => 0,
             INMODEREG => 0,
+            MREG => 0,
             OPMODEREG => 0,
-            PREG => 0
+            PREG => 1
             )
         port map (
             A => "0000000" & m_in.data1(22 downto 0),
@@ -235,13 +240,13 @@ begin
             CEALUMODE => '0',
             CEB1 => '0',
             CEB2 => '0',
-            CEC => '1',
+            CEC => '0',
             CECARRYIN => '0',
             CECTRL => '0',
             CED => '0',
             CEINMODE => '0',
-            CEM => m_in.valid,
-            CEP => '0',
+            CEM => '0',
+            CEP => m_in.valid,
             CLK => clk,
             D => (others => '0'),
             INMODE => "00000",
@@ -709,18 +714,18 @@ begin
 
     s0: DSP48E1
         generic map (
-            ACASCREG => 1,
+            ACASCREG => 0,
             ALUMODEREG => 0,
-            AREG => 1,
-            BCASCREG => 1,
-            BREG => 1,
+            AREG => 0,
+            BCASCREG => 0,
+            BREG => 0,
             CARRYINREG => 0,
             CARRYINSELREG => 0,
-            CREG => 1,
+            CREG => 0,
             INMODEREG => 0,
             MREG => 0,
             OPMODEREG => 0,
-            PREG => 0,
+            PREG => 1,
             USE_MULT => "none"
             )
         port map (
@@ -735,18 +740,18 @@ begin
             CARRYINSEL => "000",
             CARRYOUT => s0_carry,
             CEA1 => '0',
-            CEA2 => valid_1,
+            CEA2 => '0',
             CEAD => '0',
             CEALUMODE => '0',
             CEB1 => '0',
-            CEB2 => valid_1,
-            CEC => valid_1,
+            CEB2 => '0',
+            CEC => '0',
             CECARRYIN => '0',
             CECTRL => '0',
             CED => '0',
             CEINMODE => '0',
             CEM => '0',
-            CEP => '0',
+            CEP => valid_1,
             CLK => clk,
             D => (others => '0'),
             INMODE => "00000",
@@ -953,8 +958,6 @@ begin
             RSTP => '0'
             );
 
-    product(31 downto 0) <= product_lo xor (31 downto 0 => req_not);
-
     mult_out: process(all)
         variable ov : std_ulogic;
     begin
@@ -974,12 +977,15 @@ begin
     process(clk)
     begin
         if rising_edge(clk) then
-            product_lo <= m10_p(8 downto 0) & m01_p(5 downto 0) & m00_p(16 downto 0);
+            if rnot_1 = '0' then
+                product(31 downto 0) <= m10_p(8 downto 0) & m01_p(5 downto 0) & m00_p(16 downto 0);
+            else
+                product(31 downto 0) <= not (m10_p(8 downto 0) & m01_p(5 downto 0) & m00_p(16 downto 0));
+            end if;
             m_out.valid <= valid_1;
             valid_1 <= m_in.valid;
             req_32bit <= r32_1;
             r32_1 <= m_in.is_32bit;
-            req_not <= rnot_1;
             rnot_1 <= m_in.not_result;
             overflow <= ovf_in;
         end if;


### PR DESCRIPTION
Two things here:

(a) Improvements to timing in the xilinx multiplier code, involving moving some registers later in the path, making the output valid earlier in the clock cycle. I'm finding that building for a7-100 with vivado generally makes timing now with this change, although as always it's a bit random.

(b) Add a bit to the BTC memory to store whether the branch was taken, and pass that indication down to decode1. That means that if a backwards conditional direct branch was not taken, we can avoid doing the default static prediction of backwards conditional branches as being taken. This gives us an extra 2% on coremark, bringing it up to around 198.5 at 100MHz on the a7-100. Interestingly this somehow improves timing on the ECP5; I get Fmax = 61.28MHz, compared to 54.41MHz before this change.

The two changes together somehow reduce LUT  utilization on the a7-100 by 475 LUT6s while also improving timing and increasing performance. I'm not sure exactly why; presumably I have accidentally hit a sweet spot in vivado's randomness. :)
