### PR TITLE
ci: Add new Orange Crab build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        task: [ ECP5-EVN, ORANGE-CRAB ]
+        task: [ ECP5-EVN, ORANGE-CRAB, ORANGE-CRAB-0.21 ]
     runs-on: ubuntu-latest
     env:
       DOCKER: 1


### PR DESCRIPTION
This builds the Orange Crab v0.21 + litedram image on github actions.

ping @mkj 