### PR TITLE
Reduce LUT usage

### DIFF
--- a/countbits.vhdl
+++ b/countbits.vhdl
@@ -46,25 +46,6 @@ architecture behaviour of bit_counter is
     signal pc32     : sixbit2;
     signal popcnt   : std_ulogic_vector(63 downto 0);
 
-    function edgelocation(v: std_ulogic_vector; nbits: natural) return std_ulogic_vector is
-        variable p: std_ulogic_vector(nbits - 1 downto 0);
-        variable stride: natural;
-        variable b: std_ulogic;
-        variable k: natural;
-    begin
-        stride := 2;
-        for i in 0 to nbits - 1 loop
-            b := '0';
-            for j in 0 to (2**nbits / stride) - 1 loop
-                k := j * stride;
-                b := b or (v(k + stride - 1) and not v(k + (stride/2) - 1));
-            end loop;
-            p(i) := b;
-            stride := stride * 2;
-        end loop;
-        return p;
-    end function;
-
 begin
     countzero_r: process(clk)
     begin

--- a/countbits.vhdl
+++ b/countbits.vhdl
@@ -20,10 +20,11 @@ end entity bit_counter;
 architecture behaviour of bit_counter is
     -- signals for count-leading/trailing-zeroes
     signal inp : std_ulogic_vector(63 downto 0);
+    signal inp_r : std_ulogic_vector(63 downto 0);
     signal sum : std_ulogic_vector(64 downto 0);
-    signal msb_r : std_ulogic;
+    signal sum_r : std_ulogic_vector(64 downto 0);
     signal onehot : std_ulogic_vector(63 downto 0);
-    signal onehot_r : std_ulogic_vector(63 downto 0);
+    signal edge : std_ulogic_vector(63 downto 0);
     signal bitnum : std_ulogic_vector(5 downto 0);
     signal cntz : std_ulogic_vector(63 downto 0);
 
@@ -45,16 +46,36 @@ architecture behaviour of bit_counter is
     signal pc32     : sixbit2;
     signal popcnt   : std_ulogic_vector(63 downto 0);
 
+    function edgelocation(v: std_ulogic_vector; nbits: natural) return std_ulogic_vector is
+        variable p: std_ulogic_vector(nbits - 1 downto 0);
+        variable stride: natural;
+        variable b: std_ulogic;
+        variable k: natural;
+    begin
+        stride := 2;
+        for i in 0 to nbits - 1 loop
+            b := '0';
+            for j in 0 to (2**nbits / stride) - 1 loop
+                k := j * stride;
+                b := b or (v(k + stride - 1) and not v(k + (stride/2) - 1));
+            end loop;
+            p(i) := b;
+            stride := stride * 2;
+        end loop;
+        return p;
+    end function;
+
 begin
     countzero_r: process(clk)
     begin
         if rising_edge(clk) then
-            msb_r <= sum(64);
-            onehot_r <= onehot;
+            inp_r <= inp;
+            sum_r <= sum;
         end if;
     end process;
 
     countzero: process(all)
+        variable bitnum_e, bitnum_o : std_ulogic_vector(5 downto 0);
     begin
         if is_32bit = '0' then
             if count_right = '0' then
@@ -72,12 +93,16 @@ begin
         end if;
 
         sum <= std_ulogic_vector(unsigned('0' & not inp) + 1);
-        onehot <= sum(63 downto 0) and inp;
 
         -- The following occurs after a clock edge
-        bitnum <= bit_number(onehot_r);
+        edge <= sum_r(63 downto 0) or inp_r;
+        bitnum_e := edgelocation(edge, 6);
+        onehot <= sum_r(63 downto 0) and inp_r;
+        bitnum_o := bit_number(onehot);
+        bitnum(5 downto 2) <= bitnum_e(5 downto 2);
+        bitnum(1 downto 0) <= bitnum_o(1 downto 0);
 
-        cntz <= 57x"0" & msb_r & bitnum;
+        cntz <= 57x"0" & sum_r(64) & bitnum;
     end process;
 
     popcnt_r: process(clk)

--- a/fetch1.vhdl
+++ b/fetch1.vhdl
@@ -89,9 +89,8 @@ begin
                 r_int.predicted_taken <= r_next_int.predicted_taken;
                 r_int.pred_not_taken <= r_next_int.pred_not_taken;
                 r_int.predicted_nia <= r_next_int.predicted_nia;
-                r_int.rd_is_niap4 <= r_next.sequential;
+                r_int.rd_is_niap4 <= r_next_int.rd_is_niap4;
             end if;
-            r.sequential <= r_next.sequential and advance_nia;
             -- always send the up-to-date stop mark and req
             r.stop_mark <= stop_in;
             r.req <= not rst;
@@ -145,11 +144,11 @@ begin
     begin
 	v := r;
 	v_int := r_int;
-        v.sequential := '0';
         v.predicted := '0';
         v.pred_ntaken := '0';
         v_int.predicted_taken := '0';
         v_int.pred_not_taken := '0';
+        v_int.rd_is_niap4 := '0';
 
 	if rst = '1' then
 	    if alt_reset_in = '1' then
@@ -180,7 +179,7 @@ begin
             v.nia := r_int.predicted_nia;
             v.predicted := '1';
         else
-            v.sequential := '1';
+            v_int.rd_is_niap4 := '1';
             v.pred_ntaken := r_int.pred_not_taken;
             v.nia := std_ulogic_vector(unsigned(r.nia) + 4);
             if r_int.mode_32bit = '1' then

--- a/helpers.vhdl
+++ b/helpers.vhdl
@@ -30,6 +30,7 @@ package helpers is
     function bit_number(a: std_ulogic_vector(63 downto 0)) return std_ulogic_vector;
     function edgelocation(v: std_ulogic_vector; nbits: natural) return std_ulogic_vector;
     function count_left_zeroes(val: std_ulogic_vector) return std_ulogic_vector;
+    function count_right_zeroes(val: std_ulogic_vector) return std_ulogic_vector;
 end package helpers;
 
 package body helpers is
@@ -270,22 +271,28 @@ package body helpers is
         return p;
     end function;
 
-    -- Count leading zeroes operation
+    -- Count leading zeroes operations
     -- Assumes the value passed in is not zero (if it is, zero is returned)
-    function count_left_zeroes(val: std_ulogic_vector) return std_ulogic_vector is
-        variable rev: std_ulogic_vector(val'left downto val'right);
+    function count_right_zeroes(val: std_ulogic_vector) return std_ulogic_vector is
         variable sum: std_ulogic_vector(val'left downto val'right);
         variable onehot: std_ulogic_vector(val'left downto val'right);
         variable edge: std_ulogic_vector(val'left downto val'right);
         variable bn, bn_e, bn_o: std_ulogic_vector(5 downto 0);
     begin
-        rev := bit_reverse(val);
-        sum := std_ulogic_vector(- signed(rev));
-        onehot := sum and rev;
-        edge := sum or rev;
+        sum := std_ulogic_vector(- signed(val));
+        onehot := sum and val;
+        edge := sum or val;
         bn_e := edgelocation(std_ulogic_vector(resize(signed(edge), 64)), 6);
         bn_o := bit_number(std_ulogic_vector(resize(unsigned(onehot), 64)));
         bn := bn_e(5 downto 2) & bn_o(1 downto 0);
         return bn;
     end;
+
+    function count_left_zeroes(val: std_ulogic_vector) return std_ulogic_vector is
+        variable rev: std_ulogic_vector(val'left downto val'right);
+    begin
+        rev := bit_reverse(val);
+        return count_right_zeroes(rev);
+    end;
+
 end package body helpers;


### PR DESCRIPTION
This implements several optimizations to reduce LUT usage and improve timing.

Notably, there is a new algorithm here for count-leading-zeroes which generates the higher-order bits of the result with less logic. By using (v | -v) we get a value of the form 11...10...00, where we need to look for the position of the 1->0 transition. Then for example to generate bit 5 of the result (bit number of the right-most 1) we only need to look at bits 63 and 31; if they are 10 then the transition happens somewhere in the left 32 bits, so bit 5 of the result is 1.