### PR TITLE
Extend LiteDRAM VHDL wrapper to allow more than one clock line

### DIFF
--- a/core_dram_tb.vhdl
+++ b/core_dram_tb.vhdl
@@ -121,6 +121,7 @@ begin
             DRAM_ABITS => 24,
             DRAM_ALINES => 1,
             DRAM_DLINES => 16,
+            DRAM_CKLINES => 1,
             DRAM_PORT_WIDTH => 128,
             PAYLOAD_FILE => DRAM_INIT_FILE,
             PAYLOAD_SIZE => ROM_SIZE

--- a/dram_tb.vhdl
+++ b/dram_tb.vhdl
@@ -44,6 +44,7 @@ begin
             DRAM_ABITS => 24,
             DRAM_ALINES => 1,
             DRAM_DLINES => 16,
+            DRAM_CKLINES => 1,
             DRAM_PORT_WIDTH => 128,
             PAYLOAD_FILE => DRAM_INIT_FILE,
             PAYLOAD_SIZE => DRAM_INIT_SIZE

--- a/fpga/top-acorn-cle-215.vhdl
+++ b/fpga/top-acorn-cle-215.vhdl
@@ -94,6 +94,10 @@ architecture behaviour of toplevel is
     signal spi_sdat_oe : std_ulogic_vector(3 downto 0);
     signal spi_sdat_i  : std_ulogic_vector(3 downto 0);
 
+    -- ddram clock signals as vectors
+    signal ddram_clk_p_vec : std_logic_vector(0 downto 0);
+    signal ddram_clk_n_vec : std_logic_vector(0 downto 0);
+
     -- Fixup various memory sizes based on generics
     function get_bram_size return natural is
     begin
@@ -252,6 +256,9 @@ begin
 	-- but for now, assert it's 100Mhz
 	assert CLK_FREQUENCY = 100000000;
 
+	ddram_clk_p_vec <= (others => ddram_clk_p);
+	ddram_clk_n_vec <= (others => ddram_clk_n);
+
 	reset_controller: entity work.soc_reset
 	    generic map(
 		RESET_LOW => false,
@@ -272,6 +279,7 @@ begin
 		DRAM_ABITS => 26,
 		DRAM_ALINES => 16,
                 DRAM_DLINES => 16,
+                DRAM_CKLINES => 1,
                 DRAM_PORT_WIDTH => 128,
                 PAYLOAD_FILE => RAM_INIT_FILE,
                 PAYLOAD_SIZE => PAYLOAD_SIZE
@@ -304,8 +312,8 @@ begin
 		ddram_dq	=> ddram_dq,
 		ddram_dqs_p	=> ddram_dqs_p,
 		ddram_dqs_n	=> ddram_dqs_n,
-		ddram_clk_p	=> ddram_clk_p,
-		ddram_clk_n	=> ddram_clk_n,
+		ddram_clk_p	=> ddram_clk_p_vec,
+		ddram_clk_n	=> ddram_clk_n_vec,
 		ddram_cke	=> ddram_cke,
 		ddram_odt	=> ddram_odt,
 		ddram_reset_n	=> ddram_reset_n

--- a/fpga/top-arty.vhdl
+++ b/fpga/top-arty.vhdl
@@ -163,6 +163,10 @@ architecture behaviour of toplevel is
     signal gpio_out    : std_ulogic_vector(NGPIO - 1 downto 0);
     signal gpio_dir    : std_ulogic_vector(NGPIO - 1 downto 0);
 
+    -- ddram clock signals as vectors
+    signal ddram_clk_p_vec : std_logic_vector(0 downto 0);
+    signal ddram_clk_n_vec : std_logic_vector(0 downto 0);
+
     -- Fixup various memory sizes based on generics
     function get_bram_size return natural is
     begin
@@ -382,11 +386,15 @@ begin
             end if;
         end process;
 
+	ddram_clk_p_vec <= (others => ddram_clk_p);
+	ddram_clk_n_vec <= (others => ddram_clk_n);
+
         dram: entity work.litedram_wrapper
             generic map(
                 DRAM_ABITS => 24,
                 DRAM_ALINES => 14,
                 DRAM_DLINES => 16,
+                DRAM_CKLINES => 1,
                 DRAM_PORT_WIDTH => 128,
                 PAYLOAD_FILE => RAM_INIT_FILE,
                 PAYLOAD_SIZE => PAYLOAD_SIZE
@@ -419,8 +427,8 @@ begin
                 ddram_dq        => ddram_dq,
                 ddram_dqs_p     => ddram_dqs_p,
                 ddram_dqs_n     => ddram_dqs_n,
-                ddram_clk_p     => ddram_clk_p,
-                ddram_clk_n     => ddram_clk_n,
+                ddram_clk_p     => ddram_clk_p_vec,
+                ddram_clk_n     => ddram_clk_n_vec,
                 ddram_cke       => ddram_cke,
                 ddram_odt       => ddram_odt,
                 ddram_reset_n   => ddram_reset_n

--- a/fpga/top-genesys2.vhdl
+++ b/fpga/top-genesys2.vhdl
@@ -97,6 +97,10 @@ architecture behaviour of toplevel is
     signal spi_sdat_oe : std_ulogic_vector(3 downto 0);
     signal spi_sdat_i  : std_ulogic_vector(3 downto 0);
 
+    -- ddram clock signals as vectors
+    signal ddram_clk_p_vec : std_logic_vector(0 downto 0);
+    signal ddram_clk_n_vec : std_logic_vector(0 downto 0);
+
     -- Fixup various memory sizes based on generics
     function get_bram_size return natural is
     begin
@@ -270,11 +274,15 @@ begin
 		rst_out => open
 		);
 
+	ddram_clk_p_vec <= (others => ddram_clk_p);
+	ddram_clk_n_vec <= (others => ddram_clk_n);
+
 	dram: entity work.litedram_wrapper
 	    generic map(
 		DRAM_ABITS => 25,
 		DRAM_ALINES => 15,
                 DRAM_DLINES => 32,
+                DRAM_CKLINES => 1,
                 DRAM_PORT_WIDTH => 256,
                 PAYLOAD_FILE => RAM_INIT_FILE,
                 PAYLOAD_SIZE => PAYLOAD_SIZE
@@ -307,8 +315,8 @@ begin
 		ddram_dq	=> ddram_dq,
 		ddram_dqs_p	=> ddram_dqs_p,
 		ddram_dqs_n	=> ddram_dqs_n,
-		ddram_clk_p	=> ddram_clk_p,
-		ddram_clk_n	=> ddram_clk_n,
+		ddram_clk_p	=> ddram_clk_p_vec,
+		ddram_clk_n	=> ddram_clk_n_vec,
 		ddram_cke	=> ddram_cke,
 		ddram_odt	=> ddram_odt,
 		ddram_reset_n	=> ddram_reset_n

--- a/fpga/top-nexys-video.vhdl
+++ b/fpga/top-nexys-video.vhdl
@@ -139,6 +139,10 @@ architecture behaviour of toplevel is
     signal spi_sdat_oe : std_ulogic_vector(3 downto 0);
     signal spi_sdat_i  : std_ulogic_vector(3 downto 0);
 
+    -- ddram clock signals as vectors
+    signal ddram_clk_p_vec : std_logic_vector(0 downto 0);
+    signal ddram_clk_n_vec : std_logic_vector(0 downto 0);
+
     -- Fixup various memory sizes based on generics
     function get_bram_size return natural is
     begin
@@ -330,11 +334,15 @@ begin
             end if;
         end process;
 
+	ddram_clk_p_vec <= (others => ddram_clk_p);
+	ddram_clk_n_vec <= (others => ddram_clk_n);
+
 	dram: entity work.litedram_wrapper
 	    generic map(
 		DRAM_ABITS => 25,
 		DRAM_ALINES => 15,
                 DRAM_DLINES => 16,
+                DRAM_CKLINES => 1,
                 DRAM_PORT_WIDTH => 128,
                 PAYLOAD_FILE => RAM_INIT_FILE,
                 PAYLOAD_SIZE => PAYLOAD_SIZE
@@ -367,8 +375,8 @@ begin
 		ddram_dq	=> ddram_dq,
 		ddram_dqs_p	=> ddram_dqs_p,
 		ddram_dqs_n	=> ddram_dqs_n,
-		ddram_clk_p	=> ddram_clk_p,
-		ddram_clk_n	=> ddram_clk_n,
+		ddram_clk_p	=> ddram_clk_p_vec,
+		ddram_clk_n	=> ddram_clk_n_vec,
 		ddram_cke	=> ddram_cke,
 		ddram_odt	=> ddram_odt,
 		ddram_reset_n	=> ddram_reset_n

--- a/fpga/top-orangecrab0.2.vhdl
+++ b/fpga/top-orangecrab0.2.vhdl
@@ -63,10 +63,10 @@ entity toplevel is
         ddram_dm      : out std_ulogic_vector(1 downto 0);
         ddram_dq      : inout std_ulogic_vector(15 downto 0);
         ddram_dqs_p   : inout std_ulogic_vector(1 downto 0);
-        ddram_clk_p   : out std_ulogic;
+        ddram_clk_p   : out std_ulogic_vector(0 downto 0);
         -- only the positive differential pin is instantiated
         --ddram_dqs_n   : inout std_ulogic_vector(1 downto 0);
-        --ddram_clk_n   : out std_ulogic;
+        --ddram_clk_n   : out std_ulogic_vector(0 downto 0);
         ddram_cke     : out std_ulogic;
         ddram_odt     : out std_ulogic;
         ddram_reset_n : out std_ulogic;
@@ -331,6 +331,7 @@ begin
                 DRAM_ABITS => 24,
                 DRAM_ALINES => 14,
                 DRAM_DLINES => 16,
+                DRAM_CKLINES => 1,
                 DRAM_PORT_WIDTH => 128,
                 NUM_LINES => 8, -- reduce from default of 64 to make smaller/timing
                 PAYLOAD_FILE => RAM_INIT_FILE,

--- a/fpga/top-wukong-v2.vhdl
+++ b/fpga/top-wukong-v2.vhdl
@@ -139,6 +139,10 @@ architecture behaviour of toplevel is
     signal spi_sdat_oe : std_ulogic_vector(3 downto 0);
     signal spi_sdat_i  : std_ulogic_vector(3 downto 0);
 
+    -- ddram clock signals as vectors
+    signal ddram_clk_p_vec : std_ulogic_vector(0 downto 0);
+    signal ddram_clk_n_vec : std_ulogic_vector(0 downto 0);
+
     -- Fixup various memory sizes based on generics
     function get_bram_size return natural is
     begin
@@ -331,11 +335,15 @@ begin
             end if;
         end process;
 
+	ddram_clk_p_vec <= (others => ddram_clk_p);
+	ddram_clk_n_vec <= (others => ddram_clk_n);
+
         dram: entity work.litedram_wrapper
             generic map(
                 DRAM_ABITS => 24,
                 DRAM_ALINES => 14,
                 DRAM_DLINES => 16,
+                DRAM_CKLINES => 1,
                 DRAM_PORT_WIDTH => 128,
                 PAYLOAD_FILE => RAM_INIT_FILE,
                 PAYLOAD_SIZE => PAYLOAD_SIZE
@@ -368,8 +376,8 @@ begin
                 ddram_dq        => ddram_dq,
                 ddram_dqs_p     => ddram_dqs_p,
                 ddram_dqs_n     => ddram_dqs_n,
-                ddram_clk_p     => ddram_clk_p,
-                ddram_clk_n     => ddram_clk_n,
+                ddram_clk_p     => ddram_clk_p_vec,
+                ddram_clk_n     => ddram_clk_n_vec,
                 ddram_cke       => ddram_cke,
                 ddram_odt       => ddram_odt,
                 ddram_reset_n   => ddram_reset_n

--- a/litedram/extras/litedram-wrapper-l2.vhdl
+++ b/litedram/extras/litedram-wrapper-l2.vhdl
@@ -13,6 +13,7 @@ entity litedram_wrapper is
 	DRAM_ABITS      : positive;
 	DRAM_ALINES     : natural;
 	DRAM_DLINES     : natural;
+	DRAM_CKLINES    : natural;
 	DRAM_PORT_WIDTH : positive;
 
         -- Pseudo-ROM payload
@@ -69,8 +70,8 @@ entity litedram_wrapper is
         ddram_dq      : inout std_ulogic_vector(DRAM_DLINES-1 downto 0);
         ddram_dqs_p   : inout std_ulogic_vector(DRAM_DLINES/8-1 downto 0);
         ddram_dqs_n   : inout std_ulogic_vector(DRAM_DLINES/8-1 downto 0);
-        ddram_clk_p   : out std_ulogic;
-        ddram_clk_n   : out std_ulogic;
+        ddram_clk_p   : out std_ulogic_vector(DRAM_CKLINES-1 downto 0);
+        ddram_clk_n   : out std_ulogic_vector(DRAM_CKLINES-1 downto 0);
         ddram_cke     : out std_ulogic;
         ddram_odt     : out std_ulogic;
         ddram_reset_n : out std_ulogic
@@ -93,8 +94,8 @@ architecture behaviour of litedram_wrapper is
         ddram_dq                       : inout std_ulogic_vector(DRAM_DLINES-1 downto 0);
         ddram_dqs_p                    : inout std_ulogic_vector(DRAM_DLINES/8-1 downto 0);
         ddram_dqs_n                    : inout std_ulogic_vector(DRAM_DLINES/8-1 downto 0);
-        ddram_clk_p                    : out std_ulogic;
-        ddram_clk_n                    : out std_ulogic;
+        ddram_clk_p                    : out std_ulogic_vector(DRAM_CKLINES-1 downto 0);
+        ddram_clk_n                    : out std_ulogic_vector(DRAM_CKLINES-1 downto 0);
         ddram_cke                      : out std_ulogic;
         ddram_odt                      : out std_ulogic;
         ddram_reset_n                  : out std_ulogic;

--- a/litedram/extras/sim_litedram.vhdl
+++ b/litedram/extras/sim_litedram.vhdl
@@ -102,8 +102,8 @@ entity litedram_core is
 	ddram_dq                       : inout std_ulogic_vector(15 downto 0);
 	ddram_dqs_p                    : inout std_ulogic_vector(1 downto 0);
 	ddram_dqs_n                    : inout std_ulogic_vector(1 downto 0);
-	ddram_clk_p                    : out std_ulogic;
-	ddram_clk_n                    : out std_ulogic;
+	ddram_clk_p                    : out std_ulogic_vector(0 downto 0);
+	ddram_clk_n                    : out std_ulogic_vector(0 downto 0);
 	ddram_cke                      : out std_ulogic;
 	ddram_odt                      : out std_ulogic;
 	ddram_reset_n                  : out std_ulogic;


### PR DESCRIPTION
This is necessary for the upcoming Arctic Tern system enablement