### PR TITLE
mw_debug: Add STATIC_URJTAG flag

### DIFF
--- a/scripts/mw_debug/Makefile
+++ b/scripts/mw_debug/Makefile
@@ -1,10 +1,16 @@
 CFLAGS = -O2 -g -Wall -std=c99
 # CFLAGS +=  -I urjtag/urjtag/include/ -L urjtag/urjtag/src/.libs/
+#
+ifeq ($(STATIC_URJTAG), 1)
+	LIBURJTAG=-Wl,-Bstatic -lurjtag -Wl,-Bdynamic -lftdi1 -lusb-1.0 -lreadline
+else
+	LIBURJTAG=-lurjtag
+endif
 
 all: mw_debug
 
 mw_debug: mw_debug.c
-	$(CC) -o $@ $^ $(CFLAGS) -Wl,-Bstatic -lurjtag -Wl,-Bdynamic -lftdi1 -lusb-1.0 -lreadline
+	$(CC) -o $@ $^ $(CFLAGS) $(LIBURJTAG)
 
 clean:
 	rm -f mw_debug


### PR DESCRIPTION
Revert to linking dynamically by default, can statically link with
`make STATIC_URJTAG=1`

Fixes #351

Signed-off-by: Matt Johnston <matt@codeconstruct.com.au>