### PR TITLE
fix: fix icache_tb not finishing correctly

### DIFF
--- a/icache_tb.vhdl
+++ b/icache_tb.vhdl
@@ -74,6 +74,9 @@ begin
         i_out.req <= '0';
         i_out.nia <= (others => '0');
         i_out.stop_mark <= '0';
+        i_out.priv_mode <= '1';
+        i_out.virt_mode <= '0';
+        i_out.big_endian <= '0';
 
         m_out.tlbld <= '0';
         m_out.tlbie <= '0';


### PR DESCRIPTION
Setting icache to be privileged and accessing physical memory directly.
And set big_endian to 0 to correspond to the testbench result.

Signed-off-by: Tianrui Wei <tianrui@tianruiwei.com>