### PR TITLE
xics: Fix warning when comparing two std_ulogic_vectors

### DIFF
--- a/xics.vhdl
+++ b/xics.vhdl
@@ -269,7 +269,7 @@ architecture rtl of xics_ics is
     begin
         masked := x"00";
         masked(PRIO_BITS - 1 downto 0) := (others => '1');
-        if pri8 >= masked then
+        if unsigned(pri8) >= unsigned(masked) then
             return pri_masked;
         else
             return pri8(PRIO_BITS-1 downto 0);


### PR DESCRIPTION
Use unsigned() to make it clear what we are doing.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>