### PR TITLE
Remove unused sequential signal from Fetch1ToIcacheType

### DIFF
--- a/common.vhdl
+++ b/common.vhdl
@@ -200,7 +200,6 @@ package common is
         priv_mode : std_ulogic;
         big_endian : std_ulogic;
 	stop_mark: std_ulogic;
-        sequential: std_ulogic;
         predicted : std_ulogic;
         pred_ntaken : std_ulogic;
 	nia: std_ulogic_vector(63 downto 0);


### PR DESCRIPTION
GHDL synthesis is flagging a warning about this.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>