### PR TITLE
wishbone_bram_wrapper ram_addr_bits is 1 bit off

### DIFF
--- a/wishbone_bram_wrapper.vhdl
+++ b/wishbone_bram_wrapper.vhdl
@@ -24,7 +24,7 @@ entity wishbone_bram_wrapper is
 end entity wishbone_bram_wrapper;
 
 architecture behaviour of wishbone_bram_wrapper is
-    constant ram_addr_bits : integer := log2ceil(MEMORY_SIZE) - 3;
+    constant ram_addr_bits : integer := log2ceil(MEMORY_SIZE-1) - 3;
 
     -- RAM interface
     signal ram_addr : std_logic_vector(ram_addr_bits - 1 downto 0);


### PR DESCRIPTION
log2ceil() returns the number of bits required to store a value, so we
need to pass in memory_size-1, not memory_size.

Every other user of log2ceil() gets this right.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>