### PR TITLE
fpu: Fix capitalisation of Execute1ToFPUType

### DIFF
--- a/fpu.vhdl
+++ b/fpu.vhdl
@@ -16,7 +16,7 @@ entity fpu is
         clk : in std_ulogic;
         rst : in std_ulogic;
 
-        e_in  : in  Execute1toFPUType;
+        e_in  : in  Execute1ToFPUType;
         e_out : out FPUToExecute1Type;
 
         w_out : out FPUToWritebackType


### PR DESCRIPTION
While this is not an issue in VHDL, I noticed this when running
a script over the source and we may as well fix it.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>