### PR TITLE
icache: Hook up PMU events

### DIFF
--- a/icache.vhdl
+++ b/icache.vhdl
@@ -820,4 +820,7 @@ begin
         end process;
         log_out <= log_data;
     end generate;
+
+    events <= ev;
+
 end;


### PR DESCRIPTION
We weren't connecting the icache PMU events up.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>