### PR TITLE
loadstore1: Initialise PMU events

### DIFF
--- a/loadstore1.vhdl
+++ b/loadstore1.vhdl
@@ -286,6 +286,8 @@ begin
                 r3.interrupt <= '0';
                 r3.stage1_en <= '1';
                 r3.convert_lfs <= '0';
+                r3.events.load_complete <= '0';
+                r3.events.store_complete <= '0';
                 flushing <= '0';
             else
                 r1 <= r1in;


### PR DESCRIPTION
The loadstore1 PMU events are U state until a load and a store completes.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>