### PR TITLE
divider: Fix d_out.overflow U state issue

### DIFF
--- a/divider.vhdl
+++ b/divider.vhdl
@@ -42,6 +42,8 @@ begin
                 quot <= (others => '0');
                 running <= '0';
                 count <= "0000000";
+                is_32bit <= '0';
+                overflow <= '0';
             elsif d_in.valid = '1' then
                 if d_in.is_extended = '1'  then
                     dend <= '0' & d_in.dividend & x"0000000000000000";


### PR DESCRIPTION
While we should only look at this when d_out.valid = 1, we may as remove
some U state across interfaces.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>