### PR TITLE
core_debug: Initialise gspr_index

### DIFF
--- a/core_debug.vhdl
+++ b/core_debug.vhdl
@@ -154,6 +154,7 @@ begin
                 stopping <= '0';
                 terminated <= '0';
                 log_trigger_delay <= 0;
+                gspr_index <= (others => '0');
             else
                 if do_log_trigger = '1' or log_trigger_delay /= 0 then
                     if log_trigger_delay = 255 then


### PR DESCRIPTION
Another case of U state being driven out of a module.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>