### PR TITLE
Gitignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ TAGS
 litedram/build/*
 liteeth/build/*
 obj_dir/*
+/scripts/mw_debug/urjtag
+/scripts/mw_debug/mw_debug


### PR DESCRIPTION
Building the mw_debug program leaves build artifacts in
microwatt/scripts/mw_debug
causing noise in the output of `git status`.
This commit adds them to .gitignore.