### PR TITLE
Interrupts for GPIO

### DIFF
--- a/fpga/arty_a7.xdc
+++ b/fpga/arty_a7.xdc
@@ -13,18 +13,18 @@ set_property -dict { PACKAGE_PIN A9  IOSTANDARD LVCMOS33 } [get_ports { uart_mai
 # RGB LEDs
 ################################################################################
 
-set_property -dict { PACKAGE_PIN E1  IOSTANDARD LVCMOS33 } [get_ports { led0_b }];
-set_property -dict { PACKAGE_PIN F6  IOSTANDARD LVCMOS33 } [get_ports { led0_g }];
-set_property -dict { PACKAGE_PIN G6  IOSTANDARD LVCMOS33 } [get_ports { led0_r }];
-#set_property -dict { PACKAGE_PIN G4  IOSTANDARD LVCMOS33 } [get_ports { led1_b }];
-#set_property -dict { PACKAGE_PIN J4  IOSTANDARD LVCMOS33 } [get_ports { led1_g }];
-#set_property -dict { PACKAGE_PIN G3  IOSTANDARD LVCMOS33 } [get_ports { led1_r }];
-#set_property -dict { PACKAGE_PIN H4  IOSTANDARD LVCMOS33 } [get_ports { led2_b }];
-#set_property -dict { PACKAGE_PIN J2  IOSTANDARD LVCMOS33 } [get_ports { led2_g }];
-#set_property -dict { PACKAGE_PIN J3  IOSTANDARD LVCMOS33 } [get_ports { led2_r }];
-#set_property -dict { PACKAGE_PIN K2  IOSTANDARD LVCMOS33 } [get_ports { led3_b }];
-#set_property -dict { PACKAGE_PIN H6  IOSTANDARD LVCMOS33 } [get_ports { led3_g }];
-#set_property -dict { PACKAGE_PIN K1  IOSTANDARD LVCMOS33 } [get_ports { led3_r }];
+set_property -dict { PACKAGE_PIN E1  IOSTANDARD LVCMOS33 } [get_ports { led_b[0] }];
+set_property -dict { PACKAGE_PIN F6  IOSTANDARD LVCMOS33 } [get_ports { led_g[0] }];
+set_property -dict { PACKAGE_PIN G6  IOSTANDARD LVCMOS33 } [get_ports { led_r[0] }];
+set_property -dict { PACKAGE_PIN G4  IOSTANDARD LVCMOS33 } [get_ports { led_b[1] }];
+set_property -dict { PACKAGE_PIN J4  IOSTANDARD LVCMOS33 } [get_ports { led_g[1] }];
+set_property -dict { PACKAGE_PIN G3  IOSTANDARD LVCMOS33 } [get_ports { led_r[1] }];
+set_property -dict { PACKAGE_PIN H4  IOSTANDARD LVCMOS33 } [get_ports { led_b[2] }];
+set_property -dict { PACKAGE_PIN J2  IOSTANDARD LVCMOS33 } [get_ports { led_g[2] }];
+set_property -dict { PACKAGE_PIN J3  IOSTANDARD LVCMOS33 } [get_ports { led_r[2] }];
+set_property -dict { PACKAGE_PIN K2  IOSTANDARD LVCMOS33 } [get_ports { led_b[3] }];
+set_property -dict { PACKAGE_PIN H6  IOSTANDARD LVCMOS33 } [get_ports { led_g[3] }];
+set_property -dict { PACKAGE_PIN K1  IOSTANDARD LVCMOS33 } [get_ports { led_r[3] }];
 
 ################################################################################
 # Normal LEDs

--- a/fpga/arty_a7.xdc
+++ b/fpga/arty_a7.xdc
@@ -36,6 +36,24 @@ set_property -dict { PACKAGE_PIN T9  IOSTANDARD LVCMOS33 } [get_ports { led6 }];
 set_property -dict { PACKAGE_PIN T10 IOSTANDARD LVCMOS33 } [get_ports { led7 }];
 
 ################################################################################
+# Switches
+################################################################################
+
+set_property -dict { PACKAGE_PIN A8  IOSTANDARD LVCMOS33 } [get_ports { sw0 }];
+set_property -dict { PACKAGE_PIN C11 IOSTANDARD LVCMOS33 } [get_ports { sw1 }];
+set_property -dict { PACKAGE_PIN C10 IOSTANDARD LVCMOS33 } [get_ports { sw2 }];
+set_property -dict { PACKAGE_PIN A10 IOSTANDARD LVCMOS33 } [get_ports { sw3 }];
+
+################################################################################
+# Buttons
+################################################################################
+
+set_property -dict { PACKAGE_PIN D9  IOSTANDARD LVCMOS33 } [get_ports { btn0 }];
+set_property -dict { PACKAGE_PIN C9  IOSTANDARD LVCMOS33 } [get_ports { btn1 }];
+set_property -dict { PACKAGE_PIN B9  IOSTANDARD LVCMOS33 } [get_ports { btn2 }];
+set_property -dict { PACKAGE_PIN B8  IOSTANDARD LVCMOS33 } [get_ports { btn3 }];
+
+################################################################################
 # SPI Flash
 ################################################################################
 

--- a/fpga/top-arty.vhdl
+++ b/fpga/top-arty.vhdl
@@ -56,6 +56,16 @@ entity toplevel is
         spi_flash_wp_n   : inout std_ulogic;
         spi_flash_hold_n : inout std_ulogic;
 
+        -- Switches and buttons
+        btn0        : in std_ulogic;
+        btn1        : in std_ulogic;
+        btn2        : in std_ulogic;
+        btn3        : in std_ulogic;
+        sw0         : in std_ulogic;
+        sw1         : in std_ulogic;
+        sw2         : in std_ulogic;
+        sw3         : in std_ulogic;
+
         -- GPIO
         shield_io        : inout std_ulogic_vector(44 downto 0);
 
@@ -699,24 +709,33 @@ begin
     led6 <= not soc_rst;
 
     -- GPIO
-    gpio_in(0) <= shield_io(0);
-    gpio_in(1) <= shield_io(1);
-    gpio_in(2) <= shield_io(2);
-    gpio_in(3) <= shield_io(3);
-    gpio_in(4) <= shield_io(4);
-    gpio_in(5) <= shield_io(5);
-    gpio_in(6) <= shield_io(6);
-    gpio_in(7) <= shield_io(7);
+    gpio_in(10) <= btn0;
+    gpio_in(11) <= btn1;
+    gpio_in(12) <= btn2;
+    gpio_in(13) <= btn3;
+    gpio_in(14) <= sw0;
+    gpio_in(15) <= sw1;
+    gpio_in(16) <= sw2;
+    gpio_in(17) <= sw3;
+
+    gpio_in(0) <= shield_io(10);
+    gpio_in(1) <= shield_io(11);
+    gpio_in(2) <= shield_io(12);
+    gpio_in(3) <= shield_io(13);
+    gpio_in(4) <= shield_io(26);
+    gpio_in(5) <= shield_io(27);
+    gpio_in(6) <= shield_io(28);
+    gpio_in(7) <= shield_io(29);
     gpio_in(8) <= shield_io(8);
     gpio_in(9) <= shield_io(9);
-    gpio_in(10) <= shield_io(10);
-    gpio_in(11) <= shield_io(11);
-    gpio_in(12) <= shield_io(12);
-    gpio_in(13) <= shield_io(13);
-    gpio_in(14) <= shield_io(26);
-    gpio_in(15) <= shield_io(27);
-    gpio_in(16) <= shield_io(28);
-    gpio_in(17) <= shield_io(29);
+    --gpio_in(10) <= shield_io(10);
+    --gpio_in(11) <= shield_io(11);
+    --gpio_in(12) <= shield_io(12);
+    --gpio_in(13) <= shield_io(13);
+    --gpio_in(14) <= shield_io(26);
+    --gpio_in(15) <= shield_io(27);
+    --gpio_in(16) <= shield_io(28);
+    --gpio_in(17) <= shield_io(29);
     gpio_in(18) <= shield_io(30);
     gpio_in(19) <= shield_io(31);
     gpio_in(20) <= shield_io(32);

--- a/fpga/top-arty.vhdl
+++ b/fpga/top-arty.vhdl
@@ -40,9 +40,9 @@ entity toplevel is
         uart_main_rx : in  std_ulogic;
 
         -- LEDs
-        led0_b  : out std_ulogic;
-        led0_g  : out std_ulogic;
-        led0_r  : out std_ulogic;
+        led_b   : out std_ulogic_vector(3 downto 0);
+        led_g   : out std_ulogic_vector(3 downto 0);
+        led_r   : out std_ulogic_vector(3 downto 0);
         led4    : out std_ulogic;
         led5    : out std_ulogic;
         led6    : out std_ulogic;
@@ -143,9 +143,9 @@ architecture behaviour of toplevel is
     signal core_alt_reset : std_ulogic;
 
     -- Status LED
-    signal led0_b_pwm : std_ulogic;
-    signal led0_r_pwm : std_ulogic;
-    signal led0_g_pwm : std_ulogic;
+    signal led_b_pwm : std_ulogic_vector(3 downto 0);
+    signal led_r_pwm : std_ulogic_vector(3 downto 0);
+    signal led_g_pwm : std_ulogic_vector(3 downto 0);
 
     -- Dumb PWM for the LEDs, those RGB LEDs are too bright otherwise
     signal pwm_counter  : std_ulogic_vector(8 downto 0);
@@ -330,9 +330,9 @@ begin
                 pll_locked_out => system_clk_locked
                 );
 
-        led0_b_pwm <= '1';
-        led0_r_pwm <= '1';
-        led0_g_pwm <= '0';
+        led_b_pwm <= "1111";
+        led_r_pwm <= "1111";
+        led_g_pwm <= "0000";
         core_alt_reset <= '0';
 
         -- Vivado barfs on those differential signals if left
@@ -432,9 +432,9 @@ begin
                 ddram_reset_n   => ddram_reset_n
                 );
 
-        led0_b_pwm <= not dram_init_done;
-        led0_r_pwm <= dram_init_error;
-        led0_g_pwm <= dram_init_done and not dram_init_error;
+        led_b_pwm(0) <= not dram_init_done;
+        led_r_pwm(0) <= dram_init_error;
+        led_g_pwm(0) <= dram_init_done and not dram_init_error;
 
     end generate;
 
@@ -683,13 +683,13 @@ begin
         if rising_edge(system_clk) then
             pwm_counter <= std_ulogic_vector(signed(pwm_counter) + 1);
             if pwm_counter(8 downto 4) = "00000" then
-                led0_b <= led0_b_pwm;
-                led0_r <= led0_r_pwm;
-                led0_g <= led0_g_pwm;
+                led_b <= led_b_pwm;
+                led_r <= led_r_pwm;
+                led_g <= led_g_pwm;
             else
-                led0_b <= '0';
-                led0_r <= '0';
-                led0_g <= '0';
+                led_b <= "0000";
+                led_r <= "0000";
+                led_g <= "0000";
             end if;
         end if;
     end process;
@@ -732,15 +732,27 @@ begin
     gpio_in(30) <= shield_io(43);
     gpio_in(31) <= shield_io(44);
 
-    shield_io(0) <= gpio_out(0) when gpio_dir(0) = '1' else 'Z';
-    shield_io(1) <= gpio_out(1) when gpio_dir(1) = '1' else 'Z';
-    shield_io(2) <= gpio_out(2) when gpio_dir(2) = '1' else 'Z';
-    shield_io(3) <= gpio_out(3) when gpio_dir(3) = '1' else 'Z';
-    shield_io(4) <= gpio_out(4) when gpio_dir(4) = '1' else 'Z';
-    shield_io(5) <= gpio_out(5) when gpio_dir(5) = '1' else 'Z';
-    shield_io(6) <= gpio_out(6) when gpio_dir(6) = '1' else 'Z';
-    shield_io(7) <= gpio_out(7) when gpio_dir(7) = '1' else 'Z';
-    shield_io(8) <= gpio_out(8) when gpio_dir(8) = '1' else 'Z';
+    led_b_pwm(1) <= gpio_out(0) when gpio_dir(0) = '1' else 'Z';
+    led_g_pwm(1) <= gpio_out(1) when gpio_dir(1) = '1' else 'Z';
+    led_r_pwm(1) <= gpio_out(2) when gpio_dir(2) = '1' else 'Z';
+
+    led_b_pwm(2) <= gpio_out(3) when gpio_dir(3) = '1' else 'Z';
+    led_g_pwm(2) <= gpio_out(4) when gpio_dir(4) = '1' else 'Z';
+    led_r_pwm(2) <= gpio_out(5) when gpio_dir(5) = '1' else 'Z';
+
+    led_b_pwm(3) <= gpio_out(6) when gpio_dir(6) = '1' else 'Z';
+    led_g_pwm(3) <= gpio_out(7) when gpio_dir(7) = '1' else 'Z';
+    led_r_pwm(3) <= gpio_out(8) when gpio_dir(8) = '1' else 'Z';
+
+    --shield_io(0) <= gpio_out(0) when gpio_dir(0) = '1' else 'Z';
+    --shield_io(1) <= gpio_out(1) when gpio_dir(1) = '1' else 'Z';
+    --shield_io(2) <= gpio_out(2) when gpio_dir(2) = '1' else 'Z';
+    --shield_io(3) <= gpio_out(3) when gpio_dir(3) = '1' else 'Z';
+    --shield_io(4) <= gpio_out(4) when gpio_dir(4) = '1' else 'Z';
+    --shield_io(5) <= gpio_out(5) when gpio_dir(5) = '1' else 'Z';
+    --shield_io(6) <= gpio_out(6) when gpio_dir(6) = '1' else 'Z';
+    --shield_io(7) <= gpio_out(7) when gpio_dir(7) = '1' else 'Z';
+    --shield_io(8) <= gpio_out(8) when gpio_dir(8) = '1' else 'Z';
     shield_io(9) <= gpio_out(9) when gpio_dir(9) = '1' else 'Z';
     shield_io(10) <= gpio_out(10) when gpio_dir(10) = '1' else 'Z';
     shield_io(11) <= gpio_out(11) when gpio_dir(11) = '1' else 'Z';

--- a/gpio.vhdl
+++ b/gpio.vhdl
@@ -39,20 +39,37 @@ architecture behaviour of gpio is
     constant GPIO_REG_DATA_SET : std_ulogic_vector(GPIO_REG_BITS-1 downto 0) := "00100";
     constant GPIO_REG_DATA_CLR : std_ulogic_vector(GPIO_REG_BITS-1 downto 0) := "00101";
 
+    constant GPIO_REG_INT_EN   : std_ulogic_vector(GPIO_REG_BITS-1 downto 0) := "01000";
+    constant GPIO_REG_INT_STAT : std_ulogic_vector(GPIO_REG_BITS-1 downto 0) := "01001";
+    -- write 1 to clear
+    constant GPIO_REG_INT_CLR : std_ulogic_vector(GPIO_REG_BITS-1 downto 0) := "01100";
+    -- edge 0, level 1
+    constant GPIO_REG_INT_TYPE : std_ulogic_vector(GPIO_REG_BITS-1 downto 0) := "01101";
+    -- for edge: trigger on either edge = 1
+    constant GPIO_REG_INT_BOTH_EDGE : std_ulogic_vector(GPIO_REG_BITS-1 downto 0) := "01110";
+    -- for edge: rising 0, falling 1
+    -- for level: high 0, low 1
+    constant GPIO_REG_INT_LEVEL : std_ulogic_vector(GPIO_REG_BITS-1 downto 0) := "01111";
+
     -- Current output value and direction
     signal reg_data : std_ulogic_vector(NGPIO - 1 downto 0);
     signal reg_dirn : std_ulogic_vector(NGPIO - 1 downto 0);
+    signal reg_in0  : std_ulogic_vector(NGPIO - 1 downto 0);
     signal reg_in1  : std_ulogic_vector(NGPIO - 1 downto 0);
     signal reg_in2  : std_ulogic_vector(NGPIO - 1 downto 0);
+
+    signal reg_intr_en    : std_ulogic_vector(NGPIO - 1 downto 0);
+    signal reg_intr_hit   : std_ulogic_vector(NGPIO - 1 downto 0);
+    signal reg_intr_type : std_ulogic_vector(NGPIO - 1 downto 0);
+    signal reg_intr_level : std_ulogic_vector(NGPIO - 1 downto 0);
+    signal reg_intr_both : std_ulogic_vector(NGPIO - 1 downto 0);
 
     signal wb_rsp   : wb_io_slave_out;
     signal reg_out  : std_ulogic_vector(NGPIO - 1 downto 0);
 
+    constant ZEROS : std_ulogic_vector(NGPIO-1 downto 0) := (others => '0');
 begin
-
-    -- No interrupt facility for now
-    intr <= '0';
-
+    intr <= '0' when reg_intr_hit = ZEROS else '1';
     gpio_out <= reg_data;
     gpio_dir <= reg_dirn;
 
@@ -60,22 +77,62 @@ begin
     wb_rsp.ack <= wb_in.cyc and wb_in.stb;
     with wb_in.adr(GPIO_REG_BITS - 1 downto 0) select reg_out <=
         reg_data when GPIO_REG_DATA_OUT,
-        reg_in2  when GPIO_REG_DATA_IN,
+        reg_in1  when GPIO_REG_DATA_IN,
         reg_dirn when GPIO_REG_DIR,
+        reg_intr_en when GPIO_REG_INT_EN,
+        reg_intr_hit when GPIO_REG_INT_STAT,
+        reg_intr_type when GPIO_REG_INT_TYPE,
+        reg_intr_both when GPIO_REG_INT_BOTH_EDGE,
+        reg_intr_level when GPIO_REG_INT_LEVEL,
         (others => '0') when others;
     wb_rsp.dat(wb_rsp.dat'left downto NGPIO) <= (others => '0');
     wb_rsp.dat(NGPIO - 1 downto 0) <= reg_out;
     wb_rsp.stall <= '0';
 
     regs_rw: process(clk)
+       variable trig : std_logic_vector(0 to 2);
+       variable change : std_logic;
+       variable intr_hit : boolean;
     begin
         if rising_edge(clk) then
             wb_out <= wb_rsp;
+            for i in NGPIO - 1 downto 0 loop
+                -- interrupt triggers. reg_in1 is current value
+                if reg_intr_type(i) = '0' then
+                    -- edge
+                    change := '0' when (reg_in1(i) = reg_in2(i)) else '1';
+                    trig := change & reg_intr_both(i) & reg_intr_level(i);
+                    case trig is
+                        -- both
+                        when "110" | "111" => intr_hit := true;
+                        -- rising
+                        when "100" => intr_hit := reg_in1(i) = '1';
+                        -- falling
+                        when "101" => intr_hit := reg_in1(i) = '0';
+                        when others => intr_hit := false;
+                    end case;
+                else
+                    -- level
+                    intr_hit := reg_in1(i) = not reg_intr_level(i);
+                end if;
+                reg_intr_hit(i) <= '1' when intr_hit and reg_intr_en(i) = '1';
+
+            end loop;
+
+            -- previous value for interrupt edge detection
             reg_in2 <= reg_in1;
-            reg_in1 <= gpio_in;
+            -- 2 flip flops to cross from async input to sys clock domain
+            reg_in1 <= reg_in0;
+            reg_in0 <= gpio_in;
+
             if rst = '1' then
                 reg_data <= (others => '0');
                 reg_dirn <= (others => '0');
+                reg_intr_en <= (others => '0');
+                reg_intr_hit <= (others => '0');
+                reg_intr_type <= (others => '0');
+                reg_intr_both <= (others => '0');
+                reg_intr_level <= (others => '0');
                 wb_out.ack <= '0';
             else
                 if wb_in.cyc = '1' and wb_in.stb = '1' and wb_in.we = '1' then
@@ -88,6 +145,16 @@ begin
                             reg_data <= reg_data or wb_in.dat(NGPIO - 1 downto 0);
                         when GPIO_REG_DATA_CLR =>
                             reg_data <= reg_data and not wb_in.dat(NGPIO - 1 downto 0);
+                        when GPIO_REG_INT_EN =>
+                            reg_intr_en <= wb_in.dat(NGPIO - 1 downto 0);
+                        when GPIO_REG_INT_CLR =>
+                            reg_intr_hit <= reg_intr_hit and not wb_in.dat(NGPIO - 1 downto 0);
+                        when GPIO_REG_INT_TYPE =>
+                            reg_intr_type <= wb_in.dat(NGPIO - 1 downto 0);
+                        when GPIO_REG_INT_BOTH_EDGE =>
+                            reg_intr_both <= wb_in.dat(NGPIO - 1 downto 0);
+                        when GPIO_REG_INT_LEVEL =>
+                            reg_intr_level <= wb_in.dat(NGPIO - 1 downto 0);
                         when others =>
                     end case;
                 end if;
@@ -96,4 +163,4 @@ begin
     end process;
 
 end architecture behaviour;
-        
+

--- a/include/microwatt_soc.h
+++ b/include/microwatt_soc.h
@@ -26,6 +26,9 @@
  */
 #define IRQ_UART0       0
 #define IRQ_ETHERNET    1
+#define IRQ_UART1       2
+#define IRQ_SDCARD      3
+#define IRQ_GPIO        4
 
 /*
  * Register definitions for the syscon registers

--- a/include/microwatt_soc.h
+++ b/include/microwatt_soc.h
@@ -14,6 +14,7 @@
 #define XICS_ICP_BASE   0xc0004000  /* Interrupt controller */
 #define XICS_ICS_BASE   0xc0005000  /* Interrupt controller */
 #define SPI_FCTRL_BASE  0xc0006000  /* SPI flash controller registers */
+#define GPIO_BASE       0xc0007000  /* GPIO registers */
 #define DRAM_CTRL_BASE	0xc8000000  /* LiteDRAM control registers */
 #define LETH_CSR_BASE	0xc8020000  /* LiteEth CSR registers */
 #define LETH_SRAM_BASE	0xc8030000  /* LiteEth MMIO space */
@@ -158,5 +159,20 @@
 #define   SPI_REG_AUTO_CFG_CSTOUT_SHIFT         24    /* CS timeout */
 #define   SPI_REG_AUTO_CFG_CSTOUT_MASK          (0x3f << SPI_REG_AUTO_CFG_CSTOUT_SHIFT)
 
+/*
+ * Register definitions for GPIO
+ */
+#define GPIO_REG_DATA_OUT  0x00
+#define GPIO_REG_DATA_IN   0x04
+#define GPIO_REG_DIR       0x08
+#define GPIO_REG_DATA_SET  0x10
+#define GPIO_REG_DATA_CLR  0x14
+
+#define GPIO_REG_INT_EN    0x20
+#define GPIO_REG_INT_STAT  0x24
+#define GPIO_REG_INT_CLR   0x30
+#define GPIO_REG_INT_TYPE  0x34
+#define GPIO_REG_INT_BOTH_EDGE 0x38
+#define GPIO_REG_INT_LEVEL 0x3C
 
 #endif /* __MICROWATT_SOC_H */


### PR DESCRIPTION
This adds interrupts for GPIO lines. I've kept the register interface as bit-per-line split across 3 "trigger type" registers (rising/falling/level etc), though the other option would be to have perhaps one register per line taking a type value. Any suggested changes welcome - it probably needs a bit of tidying before merging.

This pull request also hooks up the GPIOs on the arty board for testing purposes.

I have a Linux driver in https://github.com/CodeConstruct/linux/commit/46348b505100d52eb197eb66750e6a72ceb1f20b based on @shenki 's https://github.com/shenki/linux/tree/microwatt-v5.16