### PR TITLE
Recognize version string "0.12" in recent OpenOCD master

### DIFF
--- a/openocd/flash-arty
+++ b/openocd/flash-arty
@@ -27,6 +27,8 @@ def get_version():
         return ""
     if a.stderr.count(b"0.11"):
         return "_openocd_v0.11"
+    if a.stderr.count(b"0.12"):
+        return "_openocd_v0.11"
 
 parser = argparse.ArgumentParser()
 parser.add_argument("file", help="file to write to flash")


### PR DESCRIPTION
Starting from 5e7612eb4, OpenOCD identifies itself as 0.12. This causes Microwatt's flash-arty script to fail.  Because neither the cfg nor the proxy bitstream are affected, we can keep treating everything as indistinguishable from 0.11.  This patch simply tests for "0.12" as an alias; it would probably be better to replace this confusing terminology with something like "single-tap/multi-tap".