### PR TITLE
Bundle the uart16550 core file

### DIFF
--- a/microwatt.core
+++ b/microwatt.core
@@ -138,7 +138,7 @@ filesets:
       depend : [":microwatt:litesdcard"]
 
   uart16550:
-      depend : ["::uart16550"]
+      depend : [":microwatt:uart16550"]
 
 targets:
   nexys_a7:

--- a/uart16550/uart16550.core
+++ b/uart16550/uart16550.core
@@ -1,0 +1,28 @@
+CAPI=2:
+name : :microwatt:uart16550:1.5.5-r1
+description : UART 16550 transceiver
+
+filesets:
+  rtl:
+    files:
+      - uart_defines.v: {is_include_file: true}
+      - raminfr.v
+      - uart_receiver.v
+      - uart_regs.v
+      - uart_rfifo.v
+      - uart_sync_flops.v
+      - uart_tfifo.v
+      - uart_top.v
+      - uart_transmitter.v
+      - uart_wb.v
+    file_type: verilogSource
+
+targets:
+  default:
+    filesets: [rtl]
+
+provider:
+  name    : github
+  user    : olofk
+  repo    : uart16550
+  version : v1.5.5


### PR DESCRIPTION
We already carry the UART verilog source, so we may as well use it instead of requiring fusesoc to import it from its library

Signed-off-by: Benjamin Herrenschmidt <benh@kernel.crashing.org>