### PR TITLE
Add VHDL-LS language server configuration

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import json
 from pathlib import Path
 from vunit import VUnit
 
@@ -15,11 +16,28 @@ PRJ.add_library("lib").add_source_files([
     src_file
     for src_file in ROOT.glob("*.vhdl")
     # Use multiply.vhd and not xilinx-mult.vhd. Use VHDL-based random.
-    if not any(exclude in str(src_file) for exclude in ["xilinx-mult", "foreign_random", "nonrandom"])
+    if not any(exclude in str(src_file) for exclude in ["xilinx-mult", "foreign_random", "nonrandom", "dmi_dtm_ecp5", "dmi_dtm_xilinx"])
 ])
 
 PRJ.add_library("unisim").add_source_files(ROOT / "sim-unisim" / "*.vhdl")
 
 PRJ.set_sim_option("disable_ieee_warnings", True)
 
+def _gen_vhdl_ls(vu):
+    """
+    Generate the vhdl_ls.toml file required by VHDL-LS language server.
+    """
+    # Repo root
+    parent = Path(__file__).parent
+
+    proj = vu._project
+    libs = proj.get_libraries()
+
+    with open(parent / 'vhdl_ls.toml', "w") as f:
+        for lib in libs:
+            f.write(f"[libraries.{lib.name}]\n")
+            files = [str(file).replace('\\', '/') for file in lib._source_files]
+            f.write(f"files = {json.dumps(files, indent=4)}\n")
+
+_gen_vhdl_ls(PRJ)
 PRJ.main()


### PR DESCRIPTION
Hi I am working on a VHDL language server (https://github.com/VHDL-LS/rust_hdl) that I think could be useful to you when developing microwatt.
It is able to analyze the entire microwatt codebase as well as its dependencies VUnit and OSVVM.
It provides type checking, goto definition and find references for the entire codebase and takes just 120 ms to load it.
The configuration file that provides the library mapping can be automatically generated by the VUnit `run.py` file and is provided by this PR. To run it you need to install the `toml` python package from `pypi`.  

The easiest way to try is to install the VSCode extension: https://marketplace.visualstudio.com/items?itemName=hbohlin.vhdl-ls
The language server is a 100% static binary that is installed automatically by the extension.
Since it is a language server (https://microsoft.github.io/language-server-protocol/) is will work in emacs and vim as well if you prefer those instead of VSCode.