### PR TITLE
Update README.md to follow the latest version linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ ln -s micropython/firmware.bin main_ram.bin
 
 ## Synthesis on Xilinx FPGAs using Vivado
 
-- Install Vivado (I'm using the free 2019.1 webpack edition).
+- Install Vivado (I'm using the free 2022.1 webpack edition).
 
 - Setup Vivado paths:
 
 ```
-source /opt/Xilinx/Vivado/2019.1/settings64.sh
+source /opt/Xilinx/Vivado/2022.1/settings64.sh
 ```
 
 - Install FuseSoC:
@@ -101,10 +101,16 @@ sudo dnf install fusesoc
   This is needed to be able to pull down fussoc library components referenced 
   by microwatt. Run
 
+- If you use artix as a reference, like the uart16550 example below, you need to install the corresponding vivado package.
+
+<p align="center">
+<img src="https://github.com/user-attachments/assets/0390507c-cdea-4fce-b2f6-d58830bea176" alt="MicroPython running on Microwatt"/>
+</p>
+
 ```
 fusesoc init
-fusesoc fetch uart16550
 fusesoc library add microwatt /path/to/microwatt
+fusesoc fetch uart16550
 ```
 
 - Build using FuseSoC. For hello world (Replace nexys_video with your FPGA board such as --target=arty_a7-100):
@@ -127,6 +133,10 @@ fusesoc run --target=nexys_video microwatt
 Mainline Linux supports Microwatt as of v5.14. The Arty A7 is the best tested
 platform, but it's also been tested on the OrangeCrab and ButterStick.
 
+<p align="center">
+<img src="https://github.com/user-attachments/assets/b26dbdaf-aa93-4ecd-a66d-d3bd29f05146" alt="MicroPython running on Microwatt"/>
+</p>
+
 1. Use buildroot to create a userspace
 
    A small change is required to glibc in order to support the VMX/AltiVec-less
@@ -134,7 +144,7 @@ platform, but it's also been tested on the OrangeCrab and ButterStick.
    VSX/AltiVec. This change is included in Joel's buildroot fork, along with a
    defconfig:
    ```
-   git clone -b microwatt https://github.com/shenki/buildroot
+   git clone -b microwatt-2022.08 https://github.com/shenki/buildroot
    cd buildroot
    make ppc64le_microwatt_defconfig
    make
@@ -148,7 +158,7 @@ platform, but it's also been tested on the OrangeCrab and ButterStick.
    cd linux
    make ARCH=powerpc microwatt_defconfig
    make ARCH=powerpc CROSS_COMPILE=powerpc64le-linux-gnu- \
-     CONFIG_INITRAMFS_SOURCE=/buildroot/output/images/rootfs.cpio -j`nproc`
+     CONFIG_INITRAMFS_SOURCE=path/to/buildroot/output/images/rootfs.cpio -j`nproc`
    ```
 
    The output is `arch/powerpc/boot/dtbImage.microwatt.elf`.
@@ -170,19 +180,86 @@ platform, but it's also been tested on the OrangeCrab and ButterStick.
 
    For the Arty A7 A35, set `FLASH_ADDRESS` to `0x300000` and pass `-f a35`.
    ```
-   microwatt/openocd/flash-arty -f a100 build/microwatt_0/arty_a7-100-vivado/microwatt_0.bit
-   microwatt/openocd/flash-arty -f a100 dtbImage.microwatt.elf -t bin -a $FLASH_ADDRESS
+   sudo microwatt/openocd/flash-arty -f a100 build/microwatt_0/arty_a7-100-vivado/microwatt_0.bit
+   sudo microwatt/openocd/flash-arty -f a100 dtbImage.microwatt.elf -t bin -a $FLASH_ADDRESS
    ```
 
 5. Connect to the second USB TTY device exposed by the FPGA
 
    ```
-   minicom -D /dev/ttyUSB1
+   sudo minicom -D /dev/ttyUSB1
    ```
+   If the cable was plugged in, unplug it when you're done and you'll see the serial console on the minicomputer. If you can't see the serial console, see below.
+   
+   go to Serial Port Setup; last two lines are Hardware and Software Flow control; just set NO both)
 
+   - https://stackoverflow.com/questions/3913246/cannot-send-character-with-minicom
+   ```
+   sudo minicom -s; 
+   ```
+   
    The gateware has firmware that will look at `FLASH_ADDRESS` and attempt to
    parse an ELF there, loading it to the address specified in the ELF header
    and jumping to it.
+
+6. SSH login
+
+  Check  your DHCP server
+
+  ```
+  $ cat /etc/default/isc-dhcp-server
+  # Defaults for isc-dhcp-server (sourced by /etc/init.d/isc-dhcp-server)
+  # Path to dhcpd's config file (default: /etc/dhcp/dhcpd.conf).
+  #DHCPDv4_CONF=/etc/dhcp/dhcpd.conf
+  #DHCPDv6_CONF=/etc/dhcp/dhcpd6.conf
+  # Path to dhcpd's PID file (default: /var/run/dhcpd.pid).
+  #DHCPDv4_PID=/var/run/dhcpd.pid
+  #DHCPDv6_PID=/var/run/dhcpd6.pid
+  # Additional options to start dhcpd with.
+  #	Don't use options -cf or -pf here; use DHCPD_CONF/ DHCPD_PID instead
+  #OPTIONS=""
+  # On what interfaces should the DHCP server (dhcpd) serve DHCP requests?
+  #	Separate multiple interfaces with spaces, e.g. "eth0 eth1".
+  INTERFACESv4="enp6s0"
+  INTERFACESv6="enp6s0"
+  ```
+
+  ```
+  $ sudo ifconfig enp6s0 192.168.0.1
+  $  sudo /etc/init.d/isc-dhcp-server restart
+  $ dhcp-lease-list
+  To get manufacturer names please download http://standards.ieee.org/regauth/oui/oui.txt to /usr/local/etc/oui.txt
+  Reading leases from /var/lib/dhcp/dhcpd.leases
+  MAC                IP              hostname       valid until         manufacturer        
+  ===============================================================================================
+  56:1a:c0:3b:c0:f2  192.168.0.6     microwatt      2024-08-17 11:52:24 -NA-  
+  ```
+
+  You can access it by first creating a new user named root on the serial port. For example, I created a user named microwatt
+
+  ```
+  $ ssh microwatt@192.168.0.6
+  microwatt@192.168.0.6's password: 
+  
+  $ uname -a
+  Linux microwatt 6.11.0-rc3-00279-ge5fa841af679 #3 Sat Aug 17 19:45:10 KST 2024 ppc64le GNU/Linux
+
+  $ cat /etc/os-release 
+  NAME=Buildroot
+  VERSION=2022.08-7-g119e742cb0
+  ID=buildroot
+  VERSION_ID=2022.08
+  PRETTY_NAME="Buildroot 2022.08"
+
+  $ cat /proc/cpuinfo 
+  processor	: 0
+  cpu		: Microwatt
+  clock		: 100.000000MHz
+  revision	: 0.0 (pvr 0063 0000)
+  
+  timebase	: 100000000
+  platform	: microwatt
+  ```
 
 ## Testing
 


### PR DESCRIPTION
Updated the documentation to follow the latest version,  microwatt-2022.08 buildroot and latest Linux kernel v6.11.0-rc3.

![2024-08-1722-08-09-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/821b7b8d-3a5c-462b-b1b6-778414cbbe10)
