### PR TITLE
ci: Use newer version of actions/upload-artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
     - run: make microwatt.json
     - run: make microwatt.bit
     - run: make microwatt.svf
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{matrix.task}}-bitstream
         path: microwatt.svf


### PR DESCRIPTION
v2 is now deprecated and causes the test run to fail.