### PR TITLE
Implement SMP

### DIFF
--- a/common.vhdl
+++ b/common.vhdl
@@ -264,7 +264,6 @@ package common is
     type ctrl_t is record
         wait_state: std_ulogic;
         run: std_ulogic;
-	tb: std_ulogic_vector(63 downto 0);
 	dec: std_ulogic_vector(63 downto 0);
 	msr: std_ulogic_vector(63 downto 0);
         cfar: std_ulogic_vector(63 downto 0);

--- a/common.vhdl
+++ b/common.vhdl
@@ -252,12 +252,14 @@ package common is
 
     -- For now, fixed 16 sources, make this either a parametric
     -- package of some sort or an unconstrainted array.
+    -- We don't know NCPUS or SRC_NUM here, so make this
+    -- large enough for 4 cpus and 16 interrupt sources for now.
     type ics_to_icp_t is record
         -- Level interrupts only, ICS just keeps prsenting the
         -- highest priority interrupt. Once handling edge, something
         -- smarter involving handshake & reject support will be needed
-        src : std_ulogic_vector(3 downto 0);
-        pri : std_ulogic_vector(7 downto 0);
+        src : std_ulogic_vector(15 downto 0);   -- 4 bits each for 4 cpus
+        pri : std_ulogic_vector(31 downto 0);   -- 8 bits each for 4 cpus
     end record;
 
     -- This needs to die...

--- a/common.vhdl
+++ b/common.vhdl
@@ -440,6 +440,11 @@ package common is
         illegal_form : std_ulogic;
         uses_tar : std_ulogic;
         uses_dscr : std_ulogic;
+        right_shift : std_ulogic;
+        rot_clear_left : std_ulogic;
+        rot_clear_right : std_ulogic;
+        rot_sign_ext : std_ulogic;
+        do_popcnt : std_ulogic;
     end record;
     constant Decode2ToExecute1Init : Decode2ToExecute1Type :=
 	(valid => '0', unit => ALU, fac => NONE, insn_type => OP_ILLEGAL, instr_tag => instr_tag_init,
@@ -462,6 +467,8 @@ package common is
          dec_ctr => '0',
          prefixed => '0', prefix => (others => '0'), illegal_suffix => '0',
          misaligned_prefix => '0', illegal_form => '0', uses_tar => '0', uses_dscr => '0',
+         right_shift => '0', rot_clear_left => '0', rot_clear_right => '0', rot_sign_ext => '0',
+         do_popcnt => '0',
          others => (others => '0'));
 
     type MultiplyInputType is record

--- a/core.vhdl
+++ b/core.vhdl
@@ -31,6 +31,9 @@ entity core is
 	-- Alternate reset (0xffff0000) for use by DRAM init fw
 	alt_reset    : in std_ulogic;
 
+        -- Global timebase
+        timebase     : in std_ulogic_vector(63 downto 0);
+
 	-- Wishbone interface
         wishbone_insn_in  : in wishbone_slave_out;
         wishbone_insn_out : out wishbone_master_out;
@@ -373,6 +376,7 @@ begin
         port map (
             clk => clk,
             rst => rst_ex1,
+            timebase => timebase,
             flush_in => flush,
 	    busy_out => ex1_busy_out,
             e_in => decode2_to_execute1,

--- a/decode2.vhdl
+++ b/decode2.vhdl
@@ -673,6 +673,14 @@ begin
             v.e.illegal_suffix := d_in.illegal_suffix;
             v.e.misaligned_prefix := d_in.misaligned_prefix;
 
+            -- rotator control signals
+            v.e.right_shift := '1' when op = OP_SHR else '0';
+            v.e.rot_clear_left := '1' when op = OP_RLC or op = OP_RLCL else '0';
+            v.e.rot_clear_right := '1' when op = OP_RLC or op = OP_RLCR else '0';
+            v.e.rot_sign_ext := '1' when op = OP_EXTSWSLI else '0';
+
+            v.e.do_popcnt := '1' when op = OP_COUNTB and d_in.insn(7 downto 6) = "11" else '0';
+
             -- check for invalid forms that cause an illegal instruction interrupt
             -- Does RA = RT for a load quadword instr, or RB = RT for lqarx?
             if d_in.decode.repeat = DRTP and

--- a/decode2.vhdl
+++ b/decode2.vhdl
@@ -227,7 +227,6 @@ architecture behaviour of decode2 is
         OP_PRTY     => "001",
         OP_CMPB     => "001",
         OP_EXTS     => "001",
-        OP_BPERM    => "001",
         OP_BREV     => "001",
         OP_BCD      => "001",
         OP_MTSPR    => "001",
@@ -256,6 +255,7 @@ architecture behaviour of decode2 is
         OP_DIVE    => "101",
         OP_MOD     => "101",
         OP_BSORT   => "100",
+        OP_BPERM   => "100",
         OP_ADDG6S  => "001",            -- misc_result
         OP_ISEL    => "010",
         OP_DARN    => "011",

--- a/execute1.vhdl
+++ b/execute1.vhdl
@@ -34,6 +34,8 @@ entity execute1 is
 	ext_irq_in : std_ulogic;
         interrupt_in : WritebackToExecute1Type;
 
+        timebase : std_ulogic_vector(63 downto 0);
+
 	-- asynchronous
         l_out : out Execute1ToLoadstore1Type;
         fp_out : out Execute1ToFPUType;
@@ -1901,8 +1903,8 @@ begin
 
     -- Slow SPR read mux
     with ex1.spr_select.sel select spr_result <=
-        ctrl.tb when SPRSEL_TB,
-        32x"0" & ctrl.tb(63 downto 32) when SPRSEL_TBU,
+        timebase when SPRSEL_TB,
+        32x"0" & timebase(63 downto 32) when SPRSEL_TBU,
         ctrl.dec when SPRSEL_DEC,
         32x"0" & PVR_MICROWATT when SPRSEL_PVR,
         log_wr_addr & ex2.log_addr_spr when SPRSEL_LOGA,
@@ -1956,16 +1958,14 @@ begin
         end if;
 
 	ctrl_tmp <= ctrl;
-	-- FIXME: run at 512MHz not core freq
-	ctrl_tmp.tb <= std_ulogic_vector(unsigned(ctrl.tb) + 1);
 	ctrl_tmp.dec <= std_ulogic_vector(unsigned(ctrl.dec) - 1);
 
         x_to_pmu.mfspr <= '0';
         x_to_pmu.mtspr <= '0';
-        x_to_pmu.tbbits(3) <= ctrl.tb(63 - 47);
-        x_to_pmu.tbbits(2) <= ctrl.tb(63 - 51);
-        x_to_pmu.tbbits(1) <= ctrl.tb(63 - 55);
-        x_to_pmu.tbbits(0) <= ctrl.tb(63 - 63);
+        x_to_pmu.tbbits(3) <= timebase(63 - 47);
+        x_to_pmu.tbbits(2) <= timebase(63 - 51);
+        x_to_pmu.tbbits(1) <= timebase(63 - 55);
+        x_to_pmu.tbbits(0) <= timebase(63 - 63);
         x_to_pmu.pmm_msr <= ctrl.msr(MSR_PMM);
         x_to_pmu.pr_msr <= ctrl.msr(MSR_PR);
 

--- a/execute1.vhdl
+++ b/execute1.vhdl
@@ -210,12 +210,9 @@ architecture behaviour of execute1 is
     signal valid_in : std_ulogic;
     signal ctrl: ctrl_t := ctrl_t_init;
     signal ctrl_tmp: ctrl_t := ctrl_t_init;
-    signal right_shift, rot_clear_left, rot_clear_right: std_ulogic;
-    signal rot_sign_ext: std_ulogic;
     signal rotator_result: std_ulogic_vector(63 downto 0);
     signal rotator_carry: std_ulogic;
     signal logical_result: std_ulogic_vector(63 downto 0);
-    signal do_popcnt: std_ulogic;
     signal countbits_result: std_ulogic_vector(63 downto 0);
     signal alu_result: std_ulogic_vector(63 downto 0);
     signal adder_result: std_ulogic_vector(63 downto 0);
@@ -454,11 +451,11 @@ begin
 	    shift => b_in(6 downto 0),
 	    insn => e_in.insn,
 	    is_32bit => e_in.is_32bit,
-	    right_shift => right_shift,
+	    right_shift => e_in.right_shift,
 	    arith => e_in.is_signed,
-	    clear_left => rot_clear_left,
-	    clear_right => rot_clear_right,
-            sign_ext_rs => rot_sign_ext,
+	    clear_left => e_in.rot_clear_left,
+	    clear_right => e_in.rot_clear_right,
+            sign_ext_rs => e_in.rot_sign_ext,
 	    result => rotator_result,
 	    carry_out => rotator_carry
 	    );
@@ -482,7 +479,7 @@ begin
             stall => stage2_stall,
 	    count_right => e_in.insn(10),
 	    is_32bit => e_in.is_32bit,
-            do_popcnt => do_popcnt,
+            do_popcnt => e_in.do_popcnt,
             datalen => e_in.data_len,
 	    result => countbits_result
 	    );
@@ -1647,14 +1644,6 @@ begin
         bypass_valid := actions.bypass_valid;
 
         irq_valid := ex1.msr(MSR_EE) and (pmu_to_x.intr or ctrl.dec(63) or ext_irq_in);
-
-	-- rotator control signals
-	right_shift <= '1' when e_in.insn_type = OP_SHR else '0';
-	rot_clear_left <= '1' when e_in.insn_type = OP_RLC or e_in.insn_type = OP_RLCL else '0';
-	rot_clear_right <= '1' when e_in.insn_type = OP_RLC or e_in.insn_type = OP_RLCR else '0';
-        rot_sign_ext <= '1' when e_in.insn_type = OP_EXTSWSLI else '0';
-
-        do_popcnt <= '1' when e_in.insn_type = OP_COUNTB and e_in.insn(7 downto 6) = "11" else '0';
 
         if valid_in = '1' then
             v.prev_op := e_in.insn_type;

--- a/fpga/top-arty.vhdl
+++ b/fpga/top-arty.vhdl
@@ -10,6 +10,7 @@ use work.wishbone_types.all;
 
 entity toplevel is
     generic (
+        CPUS               : natural  := 1;
         MEMORY_SIZE        : integer  := 16384;
         RAM_INIT_FILE      : string   := "firmware.hex";
         RESET_LOW          : boolean  := true;
@@ -241,6 +242,7 @@ begin
             MEMORY_SIZE        => BRAM_SIZE,
             RAM_INIT_FILE      => RAM_INIT_FILE,
             SIM                => false,
+            NCPUS              => CPUS,
             CLK_FREQ           => CLK_FREQUENCY,
             HAS_FPU            => HAS_FPU,
             HAS_BTC            => HAS_BTC,

--- a/include/microwatt_soc.h
+++ b/include/microwatt_soc.h
@@ -65,7 +65,8 @@
 #define   SYS_REG_UART_IS_16550			(1ull << 32)
 #define SYS_REG_GIT_INFO		0x50
 #define   SYS_REG_GIT_IS_DIRTY			(1ull << 63)
-
+#define SYS_REG_CPU_CTRL		0x58
+#define   SYS_REG_CPU_CTRL_ENABLE		0xff
 
 /*
  * Register definitions for the potato UART

--- a/logical.vhdl
+++ b/logical.vhdl
@@ -23,7 +23,6 @@ architecture behaviour of logical is
 
     signal par0, par1 : std_ulogic;
     signal parity   : std_ulogic_vector(63 downto 0);
-    signal permute  : std_ulogic_vector(7 downto 0);
 
     function bcd_to_dpd(bcd: std_ulogic_vector(11 downto 0)) return std_ulogic_vector is
         variable dpd: std_ulogic_vector(9 downto 0);
@@ -109,16 +108,6 @@ begin
             parity(32) <= par1;
         end if;
 
-        -- bit permutation
-        for i in 0 to 7 loop
-            j := i * 8;
-            if rs(j+7 downto j+6) = "00" then
-                permute(i) <= rb(to_integer(unsigned(not rs(j+5 downto j))));
-            else
-                permute(i) <= '0';
-            end if;
-        end loop;
-
         rb_adj := rb;
         if invert_in = '1' then
             rb_adj := not rb;
@@ -157,8 +146,6 @@ begin
                 tmp := parity;
             when OP_CMPB =>
                 tmp := ppc_cmpb(rs, rb);
-            when OP_BPERM =>
-                tmp := std_ulogic_vector(resize(unsigned(permute), 64));
             when OP_BCD =>
                 -- invert_in is abused to indicate direction of conversion
                 if invert_in = '0' then

--- a/microwatt.core
+++ b/microwatt.core
@@ -335,6 +335,7 @@ targets:
     default_tool: vivado
     filesets: [core, arty_a7, soc, fpga, debug_xilinx, litedram, liteeth, uart16550, xilinx_specific, litesdcard]
     parameters:
+      - cpus
       - memory_size
       - ram_init_file
       - use_litedram=true
@@ -496,6 +497,12 @@ generate:
     parameters: {vendor : xilinx, frequency : 100e6}
 
 parameters:
+  cpus:
+    datatype    : int
+    description : Number of CPU cores to include in the SoC.
+    paramtype   : generic
+    default     : 1
+
   memory_size:
     datatype    : int
     description : On-chip memory size (bytes). If no_bram is set, this is the size carved out for the DRAM payload

--- a/soc.vhdl
+++ b/soc.vhdl
@@ -966,13 +966,16 @@ begin
     end generate;
 
     xics_icp: entity work.xics_icp
+        generic map(
+            NCPUS => NCPUS
+            )
 	port map(
 	    clk => system_clk,
 	    rst => rst_xics,
 	    wb_in => wb_xics_icp_in,
 	    wb_out => wb_xics_icp_out,
             ics_in => ics_to_icp,
-	    core_irq_out => core_ext_irq(0)
+	    core_irq_out => core_ext_irq
 	    );
 
     xics_ics: entity work.xics_ics

--- a/soc.vhdl
+++ b/soc.vhdl
@@ -980,6 +980,7 @@ begin
 
     xics_ics: entity work.xics_ics
 	generic map(
+            NCPUS     => NCPUS,
 	    SRC_NUM   => 16,
 	    PRIO_BITS => 3
 	    )

--- a/soc.vhdl
+++ b/soc.vhdl
@@ -67,6 +67,7 @@ entity soc is
 	RAM_INIT_FILE      : string;
 	CLK_FREQ           : positive;
 	SIM                : boolean;
+        NCPUS              : positive := 1;
         HAS_FPU            : boolean := true;
         HAS_BTC            : boolean := true;
 	DISABLE_FLATTEN_CORE : boolean := false;
@@ -148,20 +149,18 @@ end entity soc;
 
 architecture behaviour of soc is
 
+    subtype cpu_index_t is natural range 0 to NCPUS-1;
+    type dword_percpu_array is array(cpu_index_t) of std_ulogic_vector(63 downto 0);
+
     -- internal reset
     signal soc_reset : std_ulogic;
 
     -- Wishbone master signals:
-    signal wishbone_dcore_in  : wishbone_slave_out;
-    signal wishbone_dcore_out : wishbone_master_out;
-    signal wishbone_icore_in  : wishbone_slave_out;
-    signal wishbone_icore_out : wishbone_master_out;
-    signal wishbone_debug_in  : wishbone_slave_out;
-    signal wishbone_debug_out : wishbone_master_out;
+    signal wishbone_debug_in   : wishbone_slave_out;
+    signal wishbone_debug_out  : wishbone_master_out;
 
-    -- Arbiter array (ghdl doesnt' support assigning the array
-    -- elements in the entity instantiation)
-    constant NUM_WB_MASTERS : positive := 4;
+    -- Arbiter array
+    constant NUM_WB_MASTERS : positive := NCPUS * 2 + 2;
     signal wb_masters_out : wishbone_master_out_vector(0 to NUM_WB_MASTERS-1);
     signal wb_masters_in  : wishbone_slave_out_vector(0 to NUM_WB_MASTERS-1);
 
@@ -180,7 +179,7 @@ architecture behaviour of soc is
 
     -- Syscon signals
     signal dram_at_0     : std_ulogic;
-    signal do_core_reset    : std_ulogic;
+    signal do_core_reset : std_ulogic_vector(NCPUS-1 downto 0);
     signal alt_reset     : std_ulogic;
     signal wb_syscon_in  : wb_io_master_out;
     signal wb_syscon_out : wb_io_slave_out;
@@ -210,7 +209,7 @@ architecture behaviour of soc is
     signal wb_xics_ics_out  : wb_io_slave_out;
     signal int_level_in     : std_ulogic_vector(15 downto 0);
     signal ics_to_icp       : ics_to_icp_t;
-    signal core_ext_irq     : std_ulogic;
+    signal core_ext_irq     : std_ulogic_vector(NCPUS-1 downto 0) := (others => '0');
 
     -- GPIO signals:
     signal wb_gpio_in    : wb_io_master_out;
@@ -233,12 +232,12 @@ architecture behaviour of soc is
     signal dmi_wb_dout  : std_ulogic_vector(63 downto 0);
     signal dmi_wb_req   : std_ulogic;
     signal dmi_wb_ack   : std_ulogic;
-    signal dmi_core_dout  : std_ulogic_vector(63 downto 0);
-    signal dmi_core_req   : std_ulogic;
-    signal dmi_core_ack   : std_ulogic;
+    signal dmi_core_dout  : dword_percpu_array;
+    signal dmi_core_req   : std_ulogic_vector(NCPUS-1 downto 0);
+    signal dmi_core_ack   : std_ulogic_vector(NCPUS-1 downto 0);
 
     -- Delayed/latched resets and alt_reset
-    signal rst_core    : std_ulogic;
+    signal rst_core    : std_ulogic_vector(NCPUS-1 downto 0);
     signal rst_uart    : std_ulogic;
     signal rst_xics    : std_ulogic;
     signal rst_spi     : std_ulogic;
@@ -269,6 +268,8 @@ architecture behaviour of soc is
     signal io_cycle_spi_flash : std_ulogic;
     signal io_cycle_gpio      : std_ulogic;
     signal io_cycle_external  : std_ulogic;
+
+    signal core_run_out       : std_ulogic_vector(NCPUS-1 downto 0);
 
     function wishbone_widen_data(wb : wb_io_master_out) return wishbone_master_out is
         variable wwb : wishbone_master_out;
@@ -334,7 +335,9 @@ begin
     resets: process(system_clk)
     begin
         if rising_edge(system_clk) then
-            rst_core    <= soc_reset or do_core_reset;
+            for i in 0 to NCPUS-1 loop
+                rst_core(i) <= soc_reset or do_core_reset(i);
+            end loop;
             rst_uart    <= soc_reset;
             rst_spi     <= soc_reset;
             rst_xics    <= soc_reset;
@@ -347,11 +350,12 @@ begin
         end if;
     end process;
 
-    -- Processor core
-    processor: entity work.core
+    -- Processor cores
+    processors: for i in 0 to NCPUS-1 generate
+        core: entity work.core
 	generic map(
 	    SIM => SIM,
-            CPU_INDEX => 0,
+            CPU_INDEX => i,
             HAS_FPU => HAS_FPU,
             HAS_BTC => HAS_BTC,
 	    DISABLE_FLATTEN => DISABLE_FLATTEN_CORE,
@@ -367,32 +371,31 @@ begin
 	    )
 	port map(
 	    clk => system_clk,
-	    rst => rst_core,
+	    rst => rst_core(i),
 	    alt_reset => alt_reset_d,
-            run_out => run_out,
-	    wishbone_insn_in => wishbone_icore_in,
-	    wishbone_insn_out => wishbone_icore_out,
-	    wishbone_data_in => wishbone_dcore_in,
-	    wishbone_data_out => wishbone_dcore_out,
+            run_out => core_run_out(i),
+	    wishbone_insn_in => wb_masters_in(i + NCPUS),
+	    wishbone_insn_out => wb_masters_out(i + NCPUS),
+	    wishbone_data_in => wb_masters_in(i),
+	    wishbone_data_out => wb_masters_out(i),
             wb_snoop_in => wb_snoop,
 	    dmi_addr => dmi_addr(3 downto 0),
-	    dmi_dout => dmi_core_dout,
+	    dmi_dout => dmi_core_dout(i),
 	    dmi_din => dmi_dout,
 	    dmi_wr => dmi_wr,
-	    dmi_ack => dmi_core_ack,
-	    dmi_req => dmi_core_req,
-	    ext_irq => core_ext_irq
+	    dmi_ack => dmi_core_ack(i),
+	    dmi_req => dmi_core_req(i),
+	    ext_irq => core_ext_irq(i)
 	    );
+    end generate;
+
+    run_out <= or (core_run_out);
 
     -- Wishbone bus master arbiter & mux
-    wb_masters_out <= (0 => wishbone_dcore_out,
-		       1 => wishbone_icore_out,
-                       2 => wishbone_widen_data(wishbone_dma_out),
-		       3 => wishbone_debug_out);
-    wishbone_dcore_in <= wb_masters_in(0);
-    wishbone_icore_in <= wb_masters_in(1);
-    wishbone_dma_in   <= wishbone_narrow_data(wb_masters_in(2), wishbone_dma_out.adr);
-    wishbone_debug_in <= wb_masters_in(3);
+    wb_masters_out(2*NCPUS)     <= wishbone_widen_data(wishbone_dma_out);
+    wb_masters_out(2*NCPUS + 1) <= wishbone_debug_out;
+    wishbone_dma_in   <= wishbone_narrow_data(wb_masters_in(2*NCPUS), wishbone_dma_out.adr);
+    wishbone_debug_in <= wb_masters_in(2*NCPUS + 1);
     wishbone_arbiter_0: entity work.wishbone_arbiter
 	generic map(
 	    NUM_MASTERS => NUM_WB_MASTERS
@@ -780,6 +783,7 @@ begin
     -- Syscon slave
     syscon0: entity work.syscon
 	generic map(
+            NCPUS => NCPUS,
 	    HAS_UART => true,
 	    HAS_DRAM => HAS_DRAM,
 	    BRAM_SIZE => MEMORY_SIZE,
@@ -950,7 +954,7 @@ begin
 	    wb_in => wb_xics_icp_in,
 	    wb_out => wb_xics_icp_out,
             ics_in => ics_to_icp,
-	    core_irq_out => core_ext_irq
+	    core_irq_out => core_ext_irq(0)
 	    );
 
     xics_ics: entity work.xics_ics
@@ -1034,15 +1038,15 @@ begin
 	    );
 
     -- DMI interconnect
-    dmi_intercon: process(dmi_addr, dmi_req,
-			  dmi_wb_ack, dmi_wb_dout,
-			  dmi_core_ack, dmi_core_dout)
+    dmi_intercon: process(all)
 
 	-- DMI address map (each address is a full 64-bit register)
 	--
 	-- Offset:   Size:    Slave:
 	--  0         4       Wishbone
-	-- 10        16       Core
+	-- 10        16       Core 0
+        -- 20        16       Core 1
+        -- ... and so on for NCPUS cores
 
 	type slave_type is (SLAVE_WB,
 			    SLAVE_CORE,
@@ -1053,25 +1057,29 @@ begin
 	slave := SLAVE_NONE;
 	if std_match(dmi_addr, "000000--") then
 	    slave := SLAVE_WB;
-	elsif std_match(dmi_addr, "0001----") then
+        elsif not is_X(dmi_addr) and to_integer(unsigned(dmi_addr(7 downto 4))) <= NCPUS then
 	    slave := SLAVE_CORE;
 	end if;
 
 	-- DMI muxing
 	dmi_wb_req <= '0';
-	dmi_core_req <= '0';
+        dmi_core_req <= (others => '0');
+        dmi_din <= (others => '1');
+        dmi_ack <= dmi_req;
 	case slave is
 	when SLAVE_WB =>
 	    dmi_wb_req <= dmi_req;
 	    dmi_ack <= dmi_wb_ack;
 	    dmi_din <= dmi_wb_dout;
 	when SLAVE_CORE =>
-	    dmi_core_req <= dmi_req;
-	    dmi_ack <= dmi_core_ack;
-	    dmi_din <= dmi_core_dout;
+            for i in 0 to NCPUS-1 loop
+                if not is_X(dmi_addr) and to_integer(unsigned(dmi_addr(7 downto 4))) = i + 1 then
+                    dmi_core_req(i) <= dmi_req;
+                    dmi_ack <= dmi_core_ack(i);
+                    dmi_din <= dmi_core_dout(i);
+                end if;
+            end loop;
 	when others =>
-	    dmi_ack <= dmi_req;
-	    dmi_din <= (others => '1');
 	end case;
 
 	-- SIM magic exit

--- a/xics.vhdl
+++ b/xics.vhdl
@@ -25,6 +25,9 @@ use work.common.all;
 use work.wishbone_types.all;
 
 entity xics_icp is
+    generic (
+        NCPUS        : natural := 1
+        );
     port (
         clk          : in std_logic;
         rst          : in std_logic;
@@ -33,32 +36,41 @@ entity xics_icp is
         wb_out       : out wb_io_slave_out;
 
         ics_in       : in ics_to_icp_t;
-        core_irq_out : out std_ulogic
+        core_irq_out : out std_ulogic_vector(NCPUS-1 downto 0)
         );
 end xics_icp;
 
 architecture behaviour of xics_icp is
-    type reg_internal_t is record
+    type xics_presentation_t is record
         xisr       : std_ulogic_vector(23 downto 0);
         cppr       : std_ulogic_vector(7 downto 0);
         mfrr       : std_ulogic_vector(7 downto 0);
         irq        : std_ulogic;
+    end record;
+    constant xics_presentation_t_init : xics_presentation_t :=
+        (mfrr => x"ff", -- mask everything on reset
+         irq => '0',
+         others => (others => '0'));
+    subtype cpu_index_t is natural range 0 to NCPUS-1;
+    type xicp_array_t is array(cpu_index_t) of xics_presentation_t;
+
+    type reg_internal_t is record
+        icp        : xicp_array_t;
         wb_rd_data : std_ulogic_vector(31 downto 0);
         wb_ack     : std_ulogic;
     end record;
     constant reg_internal_init : reg_internal_t :=
         (wb_ack => '0',
-         mfrr => x"ff", -- mask everything on reset
-         irq => '0',
-         others => (others => '0'));
+         wb_rd_data => (others => '0'),
+         icp => (others => xics_presentation_t_init));
 
     signal r, r_next : reg_internal_t;
 
-    -- 8 bit offsets for each presentation
-    constant XIRR_POLL : std_ulogic_vector(7 downto 0) := x"00";
-    constant XIRR      : std_ulogic_vector(7 downto 0) := x"04";
-    constant RESV0     : std_ulogic_vector(7 downto 0) := x"08";
-    constant MFRR      : std_ulogic_vector(7 downto 0) := x"0c";
+    -- 4 bit offsets for each presentation register
+    constant XIRR_POLL : std_ulogic_vector(3 downto 0) := x"0";
+    constant XIRR      : std_ulogic_vector(3 downto 0) := x"4";
+    constant RESV0     : std_ulogic_vector(3 downto 0) := x"8";
+    constant MFRR      : std_ulogic_vector(3 downto 0) := x"c";
 
 begin
 
@@ -68,7 +80,9 @@ begin
             r <= r_next;
 
             -- We delay core_irq_out by a cycle to help with timing
-            core_irq_out <= r.irq;
+            for i in 0 to NCPUS-1 loop
+                core_irq_out(i) <= r.icp(i).irq;
+            end loop;
         end if;
     end process;
 
@@ -99,94 +113,105 @@ begin
 
         v.wb_ack := '0';
 
-        xirr_accept_rd := '0';
-
         be_in := bswap(wb_in.dat);
         be_out := (others => '0');
-
         if wb_in.cyc = '1' and wb_in.stb = '1' then
             v.wb_ack := '1'; -- always ack
-            if wb_in.we = '1' then -- write
-                -- writes to both XIRR are the same
-                case wb_in.adr(5 downto 0) & "00" is
-                when XIRR_POLL =>
-                    report "ICP XIRR_POLL write";
-                    v.cppr := be_in(31 downto 24);
-                when XIRR =>
-                    v.cppr := be_in(31 downto 24);
-                    if wb_in.sel = x"f"  then -- 4 byte
-                        report "ICP XIRR write word (EOI) :" & to_hstring(be_in);
-                    elsif wb_in.sel = x"1"  then -- 1 byte
-                        report "ICP XIRR write byte (CPPR):" & to_hstring(be_in(31 downto 24));
-                    else
-                        report "ICP XIRR UNSUPPORTED write ! sel=" & to_hstring(wb_in.sel);
-                    end if;
-                when MFRR =>
-                    v.mfrr := be_in(31 downto 24);
-                    if wb_in.sel = x"f" then -- 4 bytes
-                        report "ICP MFRR write word:" & to_hstring(be_in);
-                    elsif wb_in.sel = x"1" then -- 1 byte
-                        report "ICP MFRR write byte:" & to_hstring(be_in(31 downto 24));
-                    else
-                        report "ICP MFRR UNSUPPORTED write ! sel=" & to_hstring(wb_in.sel);
-                    end if;
-                when others =>                        
-                end case;
+        end if;
 
-            else -- read
+        for i in cpu_index_t loop
+            xirr_accept_rd := '0';
 
-                case wb_in.adr(5 downto 0) & "00" is
-                when XIRR_POLL =>
-                    report "ICP XIRR_POLL read";
-                    be_out := r.cppr & r.xisr;
-                when XIRR =>
-                    report "ICP XIRR read";
-                    be_out := r.cppr & r.xisr;
-                    if wb_in.sel = x"f" then
-                        xirr_accept_rd := '1';
-                    end if;
-                when MFRR =>
-                    report "ICP MFRR read";
-                    be_out(31 downto 24) := r.mfrr;
-                when others =>                        
-                end case;
+            if wb_in.cyc = '1' and wb_in.stb = '1' and
+                to_integer(unsigned(wb_in.adr(5 downto 2))) = i then
+                if wb_in.we = '1' then -- write
+                    -- writes to both XIRR are the same
+                    case wb_in.adr(1 downto 0) & "00" is
+                        when XIRR_POLL =>
+                            report "ICP XIRR_POLL write";
+                            v.icp(i).cppr := be_in(31 downto 24);
+                        when XIRR =>
+                            v.icp(i).cppr := be_in(31 downto 24);
+                            if wb_in.sel = x"f"  then -- 4 byte
+                                report "ICP " & natural'image(i) & " XIRR write word (EOI) :" &
+                                    to_hstring(be_in);
+                            elsif wb_in.sel = x"1"  then -- 1 byte
+                                report "ICP " & natural'image(i) & " XIRR write byte (CPPR):" &
+                                    to_hstring(be_in(31 downto 24));
+                            else
+                                report "ICP " & natural'image(i) & " XIRR UNSUPPORTED write ! sel=" &
+                                    to_hstring(wb_in.sel);
+                            end if;
+                        when MFRR =>
+                            v.icp(i).mfrr := be_in(31 downto 24);
+                            if wb_in.sel = x"f" then -- 4 bytes
+                                report "ICP " & natural'image(i) & " MFRR write word:" &
+                                    to_hstring(be_in);
+                            elsif wb_in.sel = x"1" then -- 1 byte
+                                report "ICP " & natural'image(i) & " MFRR write byte:" &
+                                    to_hstring(be_in(31 downto 24));
+                            else
+                                report "ICP " & natural'image(i) & " MFRR UNSUPPORTED write ! sel=" &
+                                    to_hstring(wb_in.sel);
+                            end if;
+                        when others =>                        
+                    end case;
+
+                else -- read
+
+                    case wb_in.adr(1 downto 0) & "00" is
+                        when XIRR_POLL =>
+                            report "ICP XIRR_POLL read";
+                            be_out := r.icp(i).cppr & r.icp(i).xisr;
+                        when XIRR =>
+                            report "ICP XIRR read";
+                            be_out := r.icp(i).cppr & r.icp(i).xisr;
+                            if wb_in.sel = x"f" then
+                                xirr_accept_rd := '1';
+                            end if;
+                        when MFRR =>
+                            report "ICP MFRR read";
+                            be_out(31 downto 24) := r.icp(i).mfrr;
+                        when others =>                        
+                    end case;
+                end if;
             end if;
-        end if;
 
-        pending_priority := x"ff";
-        v.xisr := x"000000";
-        v.irq := '0';
+            pending_priority := x"ff";
+            v.icp(i).xisr := x"000000";
+            v.icp(i).irq := '0';
 
-        if ics_in.pri /= x"ff" then
-            v.xisr := x"00001" & ics_in.src;
-            pending_priority := ics_in.pri;
-        end if;
-
-        -- Check MFRR
-        if unsigned(r.mfrr) < unsigned(pending_priority) then --
-            v.xisr := x"000002"; -- special XICS MFRR IRQ source number
-            pending_priority := r.mfrr;
-        end if;
-
-        -- Accept the interrupt
-        if xirr_accept_rd = '1' then
-            report "XICS: ICP ACCEPT" &
-                " cppr:" &  to_hstring(r.cppr) &
-                " xisr:" & to_hstring(r.xisr) &
-                " mfrr:" & to_hstring(r.mfrr);
-            v.cppr := pending_priority;
-        end if;
-
-        v.wb_rd_data := bswap(be_out);
-
-        if unsigned(pending_priority) < unsigned(v.cppr) then
-            if r.irq = '0' then
-                report "IRQ set";
+            if i = 0 and ics_in.pri /= x"ff" then
+                v.icp(i).xisr := x"00001" & ics_in.src;
+                pending_priority := ics_in.pri;
             end if;
-            v.irq := '1';
-        elsif r.irq = '1' then
-            report "IRQ clr";
-        end if;
+
+            -- Check MFRR
+            if unsigned(r.icp(i).mfrr) < unsigned(pending_priority) then --
+                v.icp(i).xisr := x"000002"; -- special XICS MFRR IRQ source number
+                pending_priority := r.icp(i).mfrr;
+            end if;
+
+            -- Accept the interrupt
+            if xirr_accept_rd = '1' then
+                report "XICS " & natural'image(i) & ": ICP ACCEPT" &
+                    " cppr:" &  to_hstring(r.icp(i).cppr) &
+                    " xisr:" & to_hstring(r.icp(i).xisr) &
+                    " mfrr:" & to_hstring(r.icp(i).mfrr);
+                v.icp(i).cppr := pending_priority;
+            end if;
+
+            v.wb_rd_data := bswap(be_out);
+
+            if unsigned(pending_priority) < unsigned(v.icp(i).cppr) then
+                if r.icp(i).irq = '0' then
+                    report "CPU " & natural'image(i) & " IRQ set";
+                end if;
+                v.icp(i).irq := '1';
+            elsif r.icp(i).irq = '1' then
+                report "CPU " & natural'image(i) & " IRQ clr";
+            end if;
+        end loop;
 
         if rst = '1' then
             v := reg_internal_init;


### PR DESCRIPTION
This gives the ability to build a microwatt system with more than one processor core. The cores see a coherent view of memory and all see the same timebase value. The XICS interrupt controller now includes a presentation controller per core and the ability to direct each external interrupt source to any specific core.

Because a multi-core system is larger and therefore tends to have worse timing on FPGAs, six of these commits are just about improving timing generally.