### PR TITLE
Dcache rework to simplify and reduce dependencies

### DIFF
--- a/common.vhdl
+++ b/common.vhdl
@@ -675,6 +675,7 @@ package common is
         atomic_last : std_ulogic;
         virt_mode : std_ulogic;
         priv_mode : std_ulogic;
+        tlb_probe : std_ulogic;
 	addr : std_ulogic_vector(63 downto 0);
 	data : std_ulogic_vector(63 downto 0);          -- valid the cycle after .valid = 1
         byte_sel : std_ulogic_vector(7 downto 0);

--- a/core.vhdl
+++ b/core.vhdl
@@ -468,6 +468,7 @@ begin
 
     dcache_0: entity work.dcache
         generic map(
+            SIM => SIM,
             LINE_SIZE => 64,
             NUM_LINES => DCACHE_NUM_LINES,
             NUM_WAYS => DCACHE_NUM_WAYS,

--- a/dcache.vhdl
+++ b/dcache.vhdl
@@ -14,6 +14,7 @@ use work.wishbone_types.all;
 
 entity dcache is
     generic (
+        SIM : boolean := false;
         -- Line size in bytes
         LINE_SIZE : positive := 64;
         -- Number of lines in a set
@@ -922,10 +923,10 @@ begin
                 index := get_index(d_in.addr);
                 valid := d_in.valid;
             end if;
-            if valid = '1' then
+            if valid = '1' or not SIM then
                 cache_tag_set <= cache_tags(to_integer(index));
             else
-                cache_tag_set <= (others => '0');
+                cache_tag_set <= (others => 'X');
             end if;
         end if;
     end process;

--- a/loadstore1.vhdl
+++ b/loadstore1.vhdl
@@ -695,7 +695,6 @@ begin
                 v.flush := '1';
             when OP_DCBZ =>
                 v.dcbz := '1';
-                v.align_intr := v.nc;
             when OP_TLBIE =>
                 v.tlbie := '1';
                 v.is_slbia := l_in.insn(7);

--- a/loadstore1.vhdl
+++ b/loadstore1.vhdl
@@ -712,8 +712,8 @@ begin
                 v.mmu_op := '1';
             when others =>
         end case;
-        v.dc_req := l_in.valid and (v.load or v.store or v.sync or v.dcbz) and not v.align_intr and
-                    not hash_nop;
+        v.dc_req := l_in.valid and (v.load or v.store or v.sync or v.dcbz or v.tlbie) and
+                    not v.align_intr and not hash_nop;
         v.incomplete := v.dc_req and v.two_dwords;
 
         -- Work out controls for load and store formatting
@@ -873,7 +873,7 @@ begin
                 dawrx_match_enable(r3.dawrx(i), r1.req.virt_mode,
                                    r1.req.priv_mode, r1.req.store) then
                 dawr_match := r1.req.valid and r1.req.dc_req and not r3.dawr_upd and
-                              not (r1.req.touch or r1.req.sync or r1.req.flush);
+                              not (r1.req.touch or r1.req.sync or r1.req.flush or r1.req.tlbie);
             end if;
         end loop;
         stage1_dawr_match <= dawr_match;
@@ -918,7 +918,7 @@ begin
                 v.req.store_data := store_data;
                 v.req.dawr_intr := dawr_match;
                 v.wait_dc := r1.req.valid and r1.req.dc_req and not r1.req.load_sp and
-                             not r1.req.incomplete and not r1.req.hashcmp;
+                             not r1.req.incomplete and not r1.req.hashcmp and not r1.req.tlbie;
                 v.wait_mmu := r1.req.valid and r1.req.mmu_op;
                 if r1.req.valid = '1' and (r1.req.align_intr or r1.req.hashcmp) = '1' then
                     v.busy := '1';
@@ -1263,6 +1263,7 @@ begin
             d_out.sync <= stage1_req.sync;
             d_out.nc <= stage1_req.nc;
             d_out.reserve <= stage1_req.reserve;
+            d_out.tlb_probe <= stage1_req.tlbie;
             d_out.atomic_qw <= stage1_req.atomic_qw;
             d_out.atomic_first <= stage1_req.atomic_first;
             d_out.atomic_last <= stage1_req.atomic_last;
@@ -1279,6 +1280,7 @@ begin
             d_out.sync <= r2.req.sync;
             d_out.nc <= r2.req.nc;
             d_out.reserve <= r2.req.reserve;
+            d_out.tlb_probe <= r2.req.tlbie;
             d_out.atomic_qw <= r2.req.atomic_qw;
             d_out.atomic_first <= r2.req.atomic_first;
             d_out.atomic_last <= r2.req.atomic_last;


### PR DESCRIPTION
This reworks the dcache to try and simplify the logic and alleviate
some of the paths that have been showing up as critical paths in
synthesis. An example is a dependency of the req_is_hit signal on
the wishbone ack, which this series removes.  Overall this seems to
have reduced LUT usage and improved timing.