### PR TITLE
More architecture compliance improvements

### DIFF
--- a/common.vhdl
+++ b/common.vhdl
@@ -189,7 +189,6 @@ package common is
     constant SPRSEL_LOGD  : spr_selector := 4x"5";
     constant SPRSEL_CFAR  : spr_selector := 4x"6";
     constant SPRSEL_FSCR  : spr_selector := 4x"7";
-    constant SPRSEL_HFSCR : spr_selector := 4x"8";
     constant SPRSEL_HEIR  : spr_selector := 4x"9";
     constant SPRSEL_CTRL  : spr_selector := 4x"a";
     constant SPRSEL_DSCR  : spr_selector := 4x"b";
@@ -198,17 +197,11 @@ package common is
     constant SPRSEL_DEXCR : spr_selector := 4x"e";
     constant SPRSEL_XER   : spr_selector := 4x"f";
 
-    -- FSCR and HFSCR bit numbers
+    -- FSCR bit numbers
     constant FSCR_PREFIX   : integer := 63 - 50;
     constant FSCR_SCV      : integer := 63 - 51;
     constant FSCR_TAR      : integer := 63 - 55;
     constant FSCR_DSCR     : integer := 63 - 61;
-    constant HFSCR_PREFIX  : integer := 63 - 50;
-    constant HFSCR_MSG     : integer := 63 - 53;
-    constant HFSCR_TAR     : integer := 63 - 55;
-    constant HFSCR_PMUSPR  : integer := 63 - 60;
-    constant HFSCR_DSCR    : integer := 63 - 61;
-    constant HFSCR_FP      : integer := 63 - 63;
 
     -- FPSCR bit numbers
     constant FPSCR_FX     : integer := 63 - 32;
@@ -301,11 +294,6 @@ package common is
         fscr_scv: std_ulogic;
         fscr_tar: std_ulogic;
         fscr_dscr: std_ulogic;
-        hfscr_ic: std_ulogic_vector(3 downto 0);
-        hfscr_pref: std_ulogic;
-        hfscr_tar: std_ulogic;
-        hfscr_dscr: std_ulogic;
-        hfscr_fp: std_ulogic;
         heir: std_ulogic_vector(63 downto 0);
         dscr: std_ulogic_vector(24 downto 0);
         ciabr: std_ulogic_vector(63 downto 0);
@@ -317,7 +305,6 @@ package common is
     constant ctrl_t_init : ctrl_t :=
         (wait_state => '0', run => '1', xer_low => 18x"0",
          fscr_ic => x"0", fscr_pref => '1', fscr_scv => '1', fscr_tar => '1', fscr_dscr => '1',
-         hfscr_ic => x"0", hfscr_pref => '1', hfscr_tar => '1', hfscr_dscr => '1', hfscr_fp => '1',
          dscr => (others => '0'),
          dexcr_pnh => aspect_bits_init, dexcr_pro => aspect_bits_init,
          hdexcr_hyp => aspect_bits_init, hdexcr_enf => aspect_bits_init,

--- a/common.vhdl
+++ b/common.vhdl
@@ -82,6 +82,8 @@ package common is
     constant SPR_NOOP1  : spr_num_t := 809;
     constant SPR_NOOP2  : spr_num_t := 810;
     constant SPR_NOOP3  : spr_num_t := 811;
+    constant SPR_HMER   : spr_num_t := 336;
+    constant SPR_HMEER  : spr_num_t := 337;
 
     -- PMU registers
     constant SPR_UPMC1  : spr_num_t := 771;
@@ -97,6 +99,9 @@ package common is
     constant SPR_USIER  : spr_num_t := 768;
     constant SPR_USIAR  : spr_num_t := 780;
     constant SPR_USDAR  : spr_num_t := 781;
+    constant SPR_USIER2 : spr_num_t := 736;
+    constant SPR_USIER3 : spr_num_t := 737;
+    constant SPR_UMMCR3 : spr_num_t := 738;
     constant SPR_PMC1   : spr_num_t := 787;
     constant SPR_PMC2   : spr_num_t := 788;
     constant SPR_PMC3   : spr_num_t := 789;
@@ -110,6 +115,9 @@ package common is
     constant SPR_SIER   : spr_num_t := 784;
     constant SPR_SIAR   : spr_num_t := 796;
     constant SPR_SDAR   : spr_num_t := 797;
+    constant SPR_SIER2  : spr_num_t := 752;
+    constant SPR_SIER3  : spr_num_t := 753;
+    constant SPR_MMCR3  : spr_num_t := 754;
 
     -- GPR indices in the register file (GPR only)
     subtype gpr_index_t is std_ulogic_vector(4 downto 0);
@@ -182,12 +190,12 @@ package common is
     end record;
     constant spr_id_init : spr_id := (sel => "0000", others => '0');
 
-    constant SPRSEL_TB    : spr_selector := 4x"0";
-    constant SPRSEL_TBU   : spr_selector := 4x"1";
-    constant SPRSEL_DEC   : spr_selector := 4x"2";
-    constant SPRSEL_PVR   : spr_selector := 4x"3";
-    constant SPRSEL_LOGA  : spr_selector := 4x"4";
-    constant SPRSEL_LOGD  : spr_selector := 4x"5";
+    constant SPRSEL_ZERO  : spr_selector := 4x"0";
+    constant SPRSEL_TB    : spr_selector := 4x"1";
+    constant SPRSEL_TBU   : spr_selector := 4x"2";
+    constant SPRSEL_DEC   : spr_selector := 4x"3";
+    constant SPRSEL_PVR   : spr_selector := 4x"4";
+    constant SPRSEL_LOGR  : spr_selector := 4x"5";
     constant SPRSEL_CFAR  : spr_selector := 4x"6";
     constant SPRSEL_FSCR  : spr_selector := 4x"7";
     constant SPRSEL_LPCR  : spr_selector := 4x"8";

--- a/common.vhdl
+++ b/common.vhdl
@@ -56,6 +56,7 @@ package common is
     constant SPR_HSPRG1 : spr_num_t := 305;
     constant SPR_PID    : spr_num_t := 48;
     constant SPR_PTCR   : spr_num_t := 464;
+    constant SPR_LPCR   : spr_num_t := 318;
     constant SPR_PVR	: spr_num_t := 287;
     constant SPR_FSCR   : spr_num_t := 153;
     constant SPR_HFSCR  : spr_num_t := 190;
@@ -189,6 +190,7 @@ package common is
     constant SPRSEL_LOGD  : spr_selector := 4x"5";
     constant SPRSEL_CFAR  : spr_selector := 4x"6";
     constant SPRSEL_FSCR  : spr_selector := 4x"7";
+    constant SPRSEL_LPCR  : spr_selector := 4x"8";
     constant SPRSEL_HEIR  : spr_selector := 4x"9";
     constant SPRSEL_CTRL  : spr_selector := 4x"a";
     constant SPRSEL_DSCR  : spr_selector := 4x"b";
@@ -234,6 +236,15 @@ package common is
     constant FPSCR_XE     : integer := 63 - 60;
     constant FPSCR_NI     : integer := 63 - 61;
     constant FPSCR_RN     : integer := 63 - 63;
+
+    -- LPCR bit numbers
+    constant LPCR_HAIL    : integer := 63 - 37;
+    constant LPCR_UPRT    : integer := 63 - 41;
+    constant LPCR_HR      : integer := 63 - 43;
+    constant LPCR_LD      : integer := 63 - 46;
+    constant LPCR_HEIC    : integer := 63 - 59;
+    constant LPCR_LPES    : integer := 63 - 60;
+    constant LPCR_HVICE   : integer := 63 - 62;
 
     -- Real addresses
     -- REAL_ADDR_BITS is the number of real address bits that we store
@@ -301,6 +312,11 @@ package common is
         dexcr_pro: aspect_bits_t;
         hdexcr_hyp: aspect_bits_t;
         hdexcr_enf: aspect_bits_t;
+        lpcr_hail: std_ulogic;
+        lpcr_ld: std_ulogic;
+        lpcr_heic: std_ulogic;
+        lpcr_lpes: std_ulogic;
+        lpcr_hvice: std_ulogic;
     end record;
     constant ctrl_t_init : ctrl_t :=
         (wait_state => '0', run => '1', xer_low => 18x"0",
@@ -308,6 +324,8 @@ package common is
          dscr => (others => '0'),
          dexcr_pnh => aspect_bits_init, dexcr_pro => aspect_bits_init,
          hdexcr_hyp => aspect_bits_init, hdexcr_enf => aspect_bits_init,
+         lpcr_hail => '0', lpcr_ld => '1', lpcr_heic => '0',
+         lpcr_lpes => '0', lpcr_hvice => '0',
          others => (others => '0'));
 
     type timebase_ctrl is record
@@ -778,6 +796,7 @@ package common is
 	write_xerc_enable : std_ulogic;
 	xerc : xer_common_t;
         interrupt : std_ulogic;
+        alt_intr : std_ulogic;
         hv_intr : std_ulogic;
         is_scv : std_ulogic;
         intr_vec : intr_vector_t;
@@ -788,7 +807,6 @@ package common is
         br_taken: std_ulogic;
         abs_br: std_ulogic;
         srr1: std_ulogic_vector(15 downto 0);
-        msr: std_ulogic_vector(63 downto 0);
     end record;
     constant Execute1ToWritebackInit : Execute1ToWritebackType :=
         (valid => '0', instr_tag => instr_tag_init, rc => '0', mode_32bit => '0',
@@ -796,11 +814,11 @@ package common is
          write_xerc_enable => '0', xerc => xerc_init,
          write_data => (others => '0'), write_cr_mask => (others => '0'),
          write_cr_data => (others => '0'), write_reg => (others => '0'),
-         interrupt => '0', hv_intr => '0', is_scv => '0', intr_vec => 0,
+         interrupt => '0', alt_intr => '0', hv_intr => '0', is_scv => '0', intr_vec => 0,
          redirect => '0', redir_mode => "0000",
          last_nia => (others => '0'),
          br_last => '0', br_taken => '0', abs_br => '0',
-         srr1 => (others => '0'), msr => (others => '0'));
+         srr1 => (others => '0'));
 
     type Execute1ToFPUType is record
         valid     : std_ulogic;
@@ -885,13 +903,14 @@ package common is
         br_last : std_ulogic;
         br_taken : std_ulogic;
         interrupt : std_ulogic;
-        intr_vec : std_ulogic_vector(16 downto 0);
+        alt_intr : std_ulogic;
+        intr_vec : std_ulogic_vector(63 downto 0);
     end record;
     constant WritebackToFetch1Init : WritebackToFetch1Type :=
         (redirect => '0', virt_mode => '0', priv_mode => '0', big_endian => '0',
          mode_32bit => '0', redirect_nia => (others => '0'),
          br_last => '0', br_taken => '0', br_nia => (others => '0'),
-         interrupt => '0', intr_vec => 17x"0");
+         interrupt => '0', alt_intr => '0', intr_vec => 64x"0");
 
     type WritebackToRegisterFileType is record
 	write_reg : gspr_index_t;
@@ -917,6 +936,7 @@ package common is
         intr    : std_ulogic;
         hv_intr : std_ulogic;
         scv_int : std_ulogic;
+        alt_int : std_ulogic;
         srr1    : std_ulogic_vector(15 downto 0);
     end record;
 

--- a/core_debug.vhdl
+++ b/core_debug.vhdl
@@ -327,6 +327,9 @@ begin
                 when 5x"0e" =>
                     isram := '0';
                     sel := SPRSEL_FSCR;
+                when 5x"0f" =>
+                    isram := '0';
+                    sel := SPRSEL_LPCR;
                 when 5x"10" =>
                     isram := '0';
                     sel := SPRSEL_HEIR;

--- a/core_debug.vhdl
+++ b/core_debug.vhdl
@@ -327,9 +327,6 @@ begin
                 when 5x"0e" =>
                     isram := '0';
                     sel := SPRSEL_FSCR;
-                when 5x"0f" =>
-                    isram := '0';
-                    sel := SPRSEL_HFSCR;
                 when 5x"10" =>
                     isram := '0';
                     sel := SPRSEL_HEIR;

--- a/decode1.vhdl
+++ b/decode1.vhdl
@@ -476,14 +476,17 @@ architecture behaviour of decode1 is
             when SPR_PVR =>
                 i.sel := SPRSEL_PVR;
             when 724 =>     -- LOG_ADDR SPR
-                i.sel := SPRSEL_LOGA;
+                i.sel := SPRSEL_LOGR;
             when 725 =>     -- LOG_DATA SPR
-                i.sel := SPRSEL_LOGD;
+                i.sel := SPRSEL_LOGR;
+                i.ronly := '1';
             when SPR_UPMC1 | SPR_UPMC2 | SPR_UPMC3 | SPR_UPMC4 | SPR_UPMC5 | SPR_UPMC6 |
                 SPR_UMMCR0 | SPR_UMMCR1 | SPR_UMMCR2 | SPR_UMMCRA | SPR_USIER | SPR_USIAR | SPR_USDAR |
                 SPR_PMC1 | SPR_PMC2 | SPR_PMC3 | SPR_PMC4 | SPR_PMC5 | SPR_PMC6 |
                 SPR_MMCR0 | SPR_MMCR1 | SPR_MMCR2 | SPR_MMCRA | SPR_SIER | SPR_SIAR | SPR_SDAR =>
                 i.ispmu := '1';
+            when SPR_USIER2 | SPR_USIER3 | SPR_UMMCR3 | SPR_SIER2 | SPR_SIER3 | SPR_MMCR3 =>
+                i.sel := SPRSEL_ZERO;
             when SPR_CFAR =>
                 i.sel := SPRSEL_CFAR;
             when SPR_XER =>
@@ -515,6 +518,8 @@ architecture behaviour of decode1 is
                 i.ronly := '1';
             when SPR_NOOP0 | SPR_NOOP1 | SPR_NOOP2 | SPR_NOOP3 =>
                 i.noop := '1';
+            when SPR_HMER | SPR_HMEER =>
+                i.sel := SPRSEL_ZERO;
             when others =>
                 i.valid := '0';
         end case;

--- a/decode1.vhdl
+++ b/decode1.vhdl
@@ -490,6 +490,8 @@ architecture behaviour of decode1 is
                 i.sel := SPRSEL_XER;
             when SPR_FSCR =>
                 i.sel := SPRSEL_FSCR;
+            when SPR_LPCR =>
+                i.sel := SPRSEL_LPCR;
             when SPR_HEIR =>
                 i.sel := SPRSEL_HEIR;
             when SPR_CTRL =>

--- a/decode1.vhdl
+++ b/decode1.vhdl
@@ -490,8 +490,6 @@ architecture behaviour of decode1 is
                 i.sel := SPRSEL_XER;
             when SPR_FSCR =>
                 i.sel := SPRSEL_FSCR;
-            when SPR_HFSCR =>
-                i.sel := SPRSEL_HFSCR;
             when SPR_HEIR =>
                 i.sel := SPRSEL_HEIR;
             when SPR_CTRL =>

--- a/fetch1.vhdl
+++ b/fetch1.vhdl
@@ -391,11 +391,11 @@ begin
 		v_int.next_nia :=  RESET_ADDRESS;
 	    end if;
         elsif w_in.interrupt = '1' then
-            v_int.next_nia := 47x"0" & w_in.intr_vec(16 downto 2) & "00";
+            v_int.next_nia := w_in.intr_vec(63 downto 2) & "00";
         end if;
 	if rst /= '0' or w_in.interrupt = '1' then
             v.req := '0';
-            v.virt_mode := '0';
+            v.virt_mode := w_in.alt_intr and not rst;
             v.priv_mode := '1';
             v.big_endian := '0';
             v_int.mode_32bit := '0';

--- a/scripts/mw_debug/mw_debug.c
+++ b/scripts/mw_debug/mw_debug.c
@@ -552,7 +552,7 @@ static const char *fast_spr_names[] =
 	"lr", "ctr", "srr0", "srr1", "hsrr0", "hsrr1",
 	"sprg0", "sprg1", "sprg2", "sprg3",
 	"hsprg0", "hsprg1", "xer", "tar",
-	"fscr", "hfscr", "heir", "cfar",
+	"fscr", "unused", "heir", "cfar",
 };
 
 static const char *ldst_spr_names[] = {

--- a/scripts/mw_debug/mw_debug.c
+++ b/scripts/mw_debug/mw_debug.c
@@ -552,7 +552,7 @@ static const char *fast_spr_names[] =
 	"lr", "ctr", "srr0", "srr1", "hsrr0", "hsrr1",
 	"sprg0", "sprg1", "sprg2", "sprg3",
 	"hsprg0", "hsprg1", "xer", "tar",
-	"fscr", "unused", "heir", "cfar",
+	"fscr", "lpcr", "heir", "cfar",
 };
 
 static const char *ldst_spr_names[] = {

--- a/writeback.vhdl
+++ b/writeback.vhdl
@@ -75,6 +75,7 @@ begin
         variable hvi  : std_ulogic;
         variable scv  : std_ulogic;
         variable intr_page : std_ulogic_vector(4 downto 0);
+        variable intr_seg  : std_ulogic_vector(1 downto 0);
     begin
         w_out <= WritebackToRegisterFileInit;
         c_out <= WritebackToCrFileInit;
@@ -98,6 +99,10 @@ begin
 
         srr1 := (others => '0');
         intr_page := 5x"0";
+        if e_in.alt_intr = '1' then
+            intr_page := 5x"4";
+        end if;
+        intr_seg := e_in.alt_intr & e_in.alt_intr;
         scv := '0';
         if e_in.interrupt = '1' then
             vec := e_in.intr_vec;
@@ -105,7 +110,11 @@ begin
             hvi := e_in.hv_intr;
             scv := e_in.is_scv;
             if e_in.is_scv = '1' then
-                intr_page := 5x"17";
+                if e_in.alt_intr = '0' then
+                    intr_page := 5x"17";
+                else
+                    intr_page := 5x"3";
+                end if;
             end if;
         elsif l_in.interrupt = '1' then
             vec := l_in.intr_vec;
@@ -117,6 +126,7 @@ begin
         interrupt_out.hv_intr <= hvi;
         interrupt_out.srr1 <= srr1;
         interrupt_out.scv_int <= scv;
+        interrupt_out.alt_int <= e_in.alt_intr;
 
         if intr = '0' then
             if e_in.write_enable = '1' then
@@ -174,7 +184,8 @@ begin
 
         -- Outputs to fetch1
         f.interrupt := intr;
-        f.intr_vec := intr_page & std_ulogic_vector(to_unsigned(vec, 12));
+        f.alt_intr := e_in.alt_intr;
+        f.intr_vec := intr_seg & 45x"0" & intr_page & std_ulogic_vector(to_unsigned(vec, 12));
         f.redirect := e_in.redirect;
         f.redirect_nia := e_in.write_data;
         f.br_nia := e_in.last_nia;


### PR DESCRIPTION
The main thing here is the implementation of a minimal LPCR register
and the functions it controls around interrupt delivery and control.
It also removes the HFSCR and associated logic since that belongs to
LPAR, which Microwatt doesn't implement.