### PR TITLE
[genesys2] Fix DDR3 PHY cmd_latency

### DIFF
--- a/litedram/gen-src/genesys2.yml
+++ b/litedram/gen-src/genesys2.yml
@@ -8,7 +8,7 @@
     "memtype":    "DDR3",      # DRAM type
 
     # PHY ----------------------------------------------------------------------
-    "cmd_latency":     1,             # Command additional latency
+    "cmd_latency":     0,             # Command additional latency
     "sdram_module":    "MT41J256M16", # SDRAM modules of the board or SO-DIMM
     "sdram_module_nb": 4,             # Number of byte groups
     "sdram_rank_nb":   1,             # Number of ranks


### PR DESCRIPTION
In the fall of 2020, cmd/clk scan in liblitedram was changed in a way that required reverting `cmd_latency` being set to 1 in LiteDRAM commit `4e62d28` back to 0.  For the default in `s7ddrphy.py` this revert happened in `496cd27`, but for standalone gen the `.yml` was never updated in neither LiteDRAM nor Microwatt, leading to regression:
https://github.com/antonblanchard/microwatt/issues/363

The present commit updates the `.yml` so DRAM works on Genesys2 again.

See also
https://github.com/enjoy-digital/litedram/pull/368
for a corresponding update to the `.yml` in LiteDRAM.