### PR TITLE
scripts: Change interpreter of make_version_fusesoc.py to /usr/bin/py…

### DIFF
--- a/scripts/make_version_fusesoc.py
+++ b/scripts/make_version_fusesoc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 #
 # Simple wrapper around make_version.sh that fusesoc needs
 # Just pulls out the files_root from yaml so we know where to run.


### PR DESCRIPTION
…thon3

make_version_fusesoc.py uses /usr/bin/env python in the hashbang, which doesn't work on a number of distros in the Python 3 era. Change it to match all the other fusesoc scripts.