### PR TITLE
ECPIX-5: Fix conflict in driving soc_rst signal

### DIFF
--- a/fpga/top-ecpix5.vhdl
+++ b/fpga/top-ecpix5.vhdl
@@ -383,7 +383,7 @@ begin
             generic map(
                 RESET_LOW => RESET_LOW,
                 PLL_RESET_BITS => 18,
-                SOC_RESET_BITS => 20
+                SOC_RESET_BITS => 1
                 )
             port map(
                 ext_clk => ext_clk,
@@ -391,15 +391,13 @@ begin
                 pll_locked_in => system_clk_locked and not dram_sys_rst,
                 ext_rst_in => ext_rst_n and gsrn,
                 pll_rst_out => pll_rst,
-                rst_out => soc_rst
+                rst_out => open
                 );
 
         -- Generate SoC reset
         soc_rst_gen: process(system_clk)
         begin
-            if ext_rst_n = '0' then
-                soc_rst <= '1';
-            elsif rising_edge(system_clk) then
+            if rising_edge(system_clk) then
                 soc_rst <= dram_sys_rst or not system_clk_locked;
             end if;
         end process;


### PR DESCRIPTION
We had two drivers for soc_rst in the USE_LITEDRAM case: the reset_controller entity and the soc_rst_gen process.  This caused yosys/ghdl to give an error like "ERROR: wire not found for $posedge".  To fix it, disconnect the output from the reset_controller entity.  Also remove the asynchronous reset on the soc_rst flip-flop, as it is not necessary and could cause timing problems.