### PR TITLE
core_debug: Add DMI-accessible counters for various events

### DIFF
--- a/common.vhdl
+++ b/common.vhdl
@@ -360,6 +360,15 @@ package common is
         next_rpn: std_ulogic_vector(REAL_ADDR_BITS - MIN_LG_PGSZ - 1 downto 0);
     end record;
 
+    type FetchEventType is record
+        ierat_hit          : std_ulogic;
+        ierat_miss         : std_ulogic;
+        ierat_miss_cycles  : std_ulogic;
+        itlb_hit           : std_ulogic;
+        itlb_miss          : std_ulogic;
+        itlb_miss_resolved : std_ulogic;
+    end record;
+
     type IcacheToDecode1Type is record
 	valid: std_ulogic;
 	stop_mark: std_ulogic;
@@ -375,8 +384,9 @@ package common is
         (nia => (others => '0'), insn => (others => '0'), icode => INSN_illegal, others => '0');
 
     type IcacheEventType is record
-        icache_miss : std_ulogic;
-        itlb_miss_resolved : std_ulogic;
+        icache_hit         : std_ulogic;
+        icache_miss        : std_ulogic;
+        icache_miss_cycles : std_ulogic;
     end record;
 
     type Decode1ToDecode2Type is record
@@ -713,9 +723,12 @@ package common is
     end record;
 
     type DcacheEventType is record
+        load_hit           : std_ulogic;
         load_miss          : std_ulogic;
+        load_miss_cycles   : std_ulogic;
         store_miss         : std_ulogic;
         dcache_refill      : std_ulogic;
+        dtlb_hit           : std_ulogic;
         dtlb_miss          : std_ulogic;
         dtlb_miss_resolved : std_ulogic;
     end record;
@@ -759,6 +772,7 @@ package common is
         stall : std_ulogic;
         done  : std_ulogic;
         err   : std_ulogic;
+        miss  : std_ulogic;
         data  : std_ulogic_vector(63 downto 0);
     end record;
 
@@ -768,6 +782,25 @@ package common is
         doall : std_ulogic;
         addr  : std_ulogic_vector(63 downto 0);
         pte   : std_ulogic_vector(63 downto 0);
+    end record;
+
+    type MMUEventType is record
+        tlbsearch      : std_ulogic;
+        tlbsrch_cycles : std_ulogic;
+        tlbmiss        : std_ulogic;
+        tlbhit         : std_ulogic;
+        tlb_evictions  : std_ulogic;
+        pwcsearch      : std_ulogic;
+        pwcsrch_cycles : std_ulogic;
+        pwcmiss        : std_ulogic;
+        pwchit_2M      : std_ulogic;
+        pwchit_1G      : std_ulogic;
+        pwchit_512G    : std_ulogic;
+        tlbhit_2M      : std_ulogic;
+        pwc_evictions  : std_ulogic;
+        pagewalk       : std_ulogic;
+        pgwalk_cycles  : std_ulogic;
+        pgwalk_miss    : std_ulogic;
     end record;
 
     type Loadstore1ToWritebackType is record

--- a/core.vhdl
+++ b/core.vhdl
@@ -17,6 +17,7 @@ entity core is
         HAS_BTC : boolean := true;
 	ALT_RESET_ADDRESS : std_ulogic_vector(63 downto 0) := (others => '0');
         LOG_LENGTH : natural := 512;
+        HAS_DMI_COUNTERS : boolean := false;
         ICACHE_NUM_LINES : natural := 64;
         ICACHE_NUM_WAYS : natural := 2;
         ICACHE_TLB_SIZE : natural := 64;
@@ -171,10 +172,12 @@ architecture behave of core is
     signal ctrl_debug : ctrl_t;
 
     -- PMU event bus
+    signal fetch_events     : FetchEventType;
     signal icache_events    : IcacheEventType;
     signal loadstore_events : Loadstore1EventType;
     signal dcache_events    : DcacheEventType;
     signal writeback_events : WritebackEventType;
+    signal mmu_events       : MMUEventType;
 
     -- Debug status
     signal dbg_core_is_stopped: std_ulogic;
@@ -247,6 +250,7 @@ begin
             d_in => decode1_to_fetch1,
             w_in => writeback_to_fetch1,
             i_out => fetch1_to_icache,
+            events => fetch_events,
             log_out => log_data(42 downto 0)
             );
 
@@ -403,6 +407,7 @@ begin
             ls_events => loadstore_events,
             dc_events => dcache_events,
             ic_events => icache_events,
+            f_events => fetch_events,
             msg_out => msg_out,
             msg_in => msg_in,
             run_out => run_out,
@@ -470,7 +475,8 @@ begin
             l_out => mmu_to_loadstore1,
             d_out => mmu_to_dcache,
             d_in => dcache_to_mmu,
-            i_out => mmu_to_itlb
+            i_out => mmu_to_itlb,
+            ev => mmu_events
             );
 
     dcache_0: entity work.dcache
@@ -520,7 +526,8 @@ begin
 
     debug_0: entity work.core_debug
         generic map (
-            LOG_LENGTH => LOG_LENGTH
+            LOG_LENGTH => LOG_LENGTH,
+            HAS_DMI_COUNTERS => HAS_DMI_COUNTERS
             )
 	port map (
 	    clk => clk,
@@ -537,7 +544,7 @@ begin
 	    terminate => terminate,
 	    core_stopped => dbg_core_is_stopped,
 	    nia => fetch1_to_icache.nia,
-            msr => ctrl_debug.msr,
+            ctrl => ctrl_debug,
             wb_snoop_in => wb_snoop_in,
             dbg_gpr_req => dbg_gpr_req,
             dbg_gpr_ack => dbg_gpr_ack,
@@ -555,7 +562,12 @@ begin
             log_read_addr => log_rd_addr,
             log_read_data => log_rd_data,
             log_write_addr => log_wr_addr,
-	    terminated_out => terminated_out
+	    terminated_out => terminated_out,
+            fetch_events => fetch_events,
+            icache_events => icache_events,
+            dcache_events => dcache_events,
+            wback_events => writeback_events,
+            mmu_events => mmu_events
 	    );
 
 end behave;

--- a/core_debug.vhdl
+++ b/core_debug.vhdl
@@ -10,7 +10,9 @@ use work.wishbone_types.all;
 entity core_debug is
     generic (
         -- Length of log buffer
-        LOG_LENGTH : natural := 512
+        LOG_LENGTH       : natural := 512;
+        -- Include logic for DMI-accessible performance counters
+        HAS_DMI_COUNTERS : boolean := false
         );
     port (
         clk             : in std_logic;
@@ -32,7 +34,7 @@ entity core_debug is
         terminate       : in std_ulogic;
         core_stopped    : in std_ulogic;
         nia             : in std_ulogic_vector(63 downto 0);
-        msr             : in std_ulogic_vector(63 downto 0);
+        ctrl            : in ctrl_t;
         wb_snoop_in     : in wishbone_master_out := wishbone_master_out_init;
 
         -- GPR/FPR register read port
@@ -60,7 +62,12 @@ entity core_debug is
         log_write_addr  : out std_ulogic_vector(31 downto 0);
 
         -- Misc
-        terminated_out  : out std_ulogic
+        terminated_out  : out std_ulogic;
+        fetch_events    : in FetchEventType;
+        icache_events   : in IcacheEventType;
+        dcache_events   : in DcacheEventType;
+        wback_events    : in WritebackEventType;
+        mmu_events      : in MMUEventType
         );
 end core_debug;
 
@@ -110,6 +117,10 @@ architecture behave of core_debug is
 
     constant LOG_INDEX_BITS : natural := log2(LOG_LENGTH);
 
+    -- debug counter index and data registers
+    constant DBG_CORE_CNT_ADDR       : std_ulogic_vector(3 downto 0) := "1100";
+    constant DBG_CORE_CNT_DATA       : std_ulogic_vector(3 downto 0) := "1101";
+
     -- Some internal wires
     signal stat_reg : std_ulogic_vector(63 downto 0);
 
@@ -138,6 +149,10 @@ architecture behave of core_debug is
     signal dmi_read_log_data_1 : std_ulogic;
     signal log_trigger_delay   : integer range 0 to 255 := 0;
 
+    signal cnt_addr_lo        : std_ulogic_vector(2 downto 0) := "000";
+    signal cnt_addr_hi        : std_ulogic_vector(2 downto 0) := "000";
+    signal cnt_data           : unsigned(47 downto 0) := 48x"0";
+
 begin
        -- Single cycle register accesses on DMI except for GSPR data
     dmi_ack <= dmi_req when dmi_addr /= DBG_CORE_GSPR_DATA
@@ -158,12 +173,14 @@ begin
     with dmi_addr select dmi_dout <=
         stat_reg        when DBG_CORE_STAT,
         nia             when DBG_CORE_NIA,
-        msr             when DBG_CORE_MSR,
+        ctrl.msr        when DBG_CORE_MSR,
         gspr_data       when DBG_CORE_GSPR_DATA,
         log_write_addr & log_dmi_addr when DBG_CORE_LOG_ADDR,
         log_dmi_data    when DBG_CORE_LOG_DATA,
         log_dmi_trigger when DBG_CORE_LOG_TRIGGER,
         log_mem_trigger when DBG_CORE_LOG_MTRIGGER,
+        58x"0" & cnt_addr_hi & cnt_addr_lo when DBG_CORE_CNT_ADDR,
+        16x"0" & std_ulogic_vector(cnt_data) when DBG_CORE_CNT_DATA,
         (others => '0') when others;
 
     -- DMI writes
@@ -238,6 +255,9 @@ begin
                             log_dmi_trigger <= dmi_din;
                         elsif dmi_addr = DBG_CORE_LOG_MTRIGGER then
                             log_mem_trigger <= dmi_din;
+                        elsif dmi_addr = DBG_CORE_CNT_ADDR then
+                            cnt_addr_hi <= dmi_din(5 downto 3);
+                            cnt_addr_lo <= dmi_din(2 downto 0);
                         end if;
                     else
                         report("DMI read from " & to_string(dmi_addr));
@@ -353,6 +373,228 @@ begin
     core_rst <= do_reset;
     icache_rst <= do_icreset;
     terminated_out <= terminated;
+
+    -- DMI-accessible performance counters
+    dmi_ctrs : if HAS_DMI_COUNTERS generate
+        signal cnt_dat0           : unsigned(47 downto 0);
+        signal cnt_dat1           : unsigned(47 downto 0);
+        signal cnt_dat2           : unsigned(47 downto 0);
+        signal cnt_dat3           : unsigned(47 downto 0);
+        signal cnt_dat4           : unsigned(47 downto 0);
+        signal cnt_data_r0        : unsigned(47 downto 0);
+        signal cnt_data_r1        : unsigned(47 downto 0);
+        signal cnt_data_r2        : unsigned(47 downto 0);
+        signal cnt_data_r3        : unsigned(47 downto 0);
+        signal tlbsrch_cnt        : unsigned(39 downto 0) := 40x"0";
+        signal tlbsrch_cyc_cnt    : unsigned(47 downto 0) := 48x"0";
+        signal tlbmiss_cnt        : unsigned(39 downto 0) := 40x"0";
+        signal tlbhit_cnt         : unsigned(39 downto 0) := 40x"0";
+        signal tlb_evict_cnt      : unsigned(39 downto 0) := 40x"0";
+        signal pagewalk_cnt       : unsigned(39 downto 0) := 40x"0";
+        signal pgwalk_cyc_cnt     : unsigned(47 downto 0) := 48x"0";
+        signal nonwait_cycles     : unsigned(47 downto 0) := 48x"0";
+        signal icache_hit_cnt     : unsigned(39 downto 0) := 40x"0";
+        signal icache_miss_cnt    : unsigned(39 downto 0) := 40x"0";
+        signal icache_miss_cycles : unsigned(47 downto 0) := 48x"0";
+        signal dcache_hit_cnt     : unsigned(39 downto 0) := 40x"0";
+        signal dcache_miss_cnt    : unsigned(39 downto 0) := 40x"0";
+        signal dcache_miss_cycles : unsigned(47 downto 0) := 48x"0";
+        signal dtlb_hit_cnt       : unsigned(39 downto 0) := 40x"0";
+        signal dtlb_miss_cnt      : unsigned(39 downto 0) := 40x"0";
+        signal ierat_hit_cnt      : unsigned(39 downto 0) := 40x"0";
+        signal ierat_miss_cnt     : unsigned(39 downto 0) := 40x"0";
+        signal ierat_miss_cycles  : unsigned(47 downto 0) := 48x"0";
+        signal itlb_hit_cnt       : unsigned(39 downto 0) := 40x"0";
+        signal itlb_miss_cnt      : unsigned(39 downto 0) := 40x"0";
+        signal instr_cmp_cnt      : unsigned(39 downto 0) := 40x"0";
+        signal pwcsrch_cnt        : unsigned(39 downto 0) := 40x"0";
+        signal pwcsrch_cyc_cnt    : unsigned(47 downto 0) := 48x"0";
+        signal pwcmiss_cnt        : unsigned(39 downto 0) := 40x"0";
+        signal pwchit_2M_cnt      : unsigned(39 downto 0) := 40x"0";
+        signal pwchit_1G_cnt      : unsigned(39 downto 0) := 40x"0";
+        signal pwchit_512G_cnt    : unsigned(39 downto 0) := 40x"0";
+        signal pwc_evict_cnt      : unsigned(39 downto 0) := 40x"0";
+        signal tlbhit_2M_cnt      : unsigned(39 downto 0) := 40x"0";
+        signal mmu_dc_miss_cnt    : unsigned(39 downto 0) := 40x"0";
+
+    begin
+        cnt_dat0 <= x"00" & tlbsrch_cnt     when cnt_addr_lo = 3x"0" else
+                    tlbsrch_cyc_cnt         when cnt_addr_lo = 3x"1" else
+                    x"00" & tlbmiss_cnt     when cnt_addr_lo = 3x"2" else
+                    x"00" & tlbhit_cnt      when cnt_addr_lo = 3x"3" else
+                    x"00" & tlbhit_2M_cnt   when cnt_addr_lo = 3x"4" else
+                    x"00" & pagewalk_cnt    when cnt_addr_lo = 3x"5" else
+                    pgwalk_cyc_cnt          when cnt_addr_lo = 3x"6" else
+                    x"00" & pwcsrch_cnt     when cnt_addr_lo = 3x"7" else
+                    48x"0";
+        cnt_dat1 <= pwcsrch_cyc_cnt         when cnt_addr_lo = 3x"0" else
+                    x"00" & pwcmiss_cnt     when cnt_addr_lo = 3x"1" else
+                    x"00" & pwchit_2M_cnt   when cnt_addr_lo = 3x"2" else
+                    x"00" & pwchit_1G_cnt   when cnt_addr_lo = 3x"3" else
+                    x"00" & pwchit_512G_cnt when cnt_addr_lo = 3x"4" else
+                    x"00" & pwc_evict_cnt   when cnt_addr_lo = 3x"5" else
+                    x"00" & tlb_evict_cnt   when cnt_addr_lo = 3x"6" else
+                    x"00" & mmu_dc_miss_cnt when cnt_addr_lo = 3x"7" else
+                    48x"0";
+        cnt_dat2 <= x"00" & instr_cmp_cnt   when cnt_addr_lo = 3x"0" else
+                    nonwait_cycles          when cnt_addr_lo = 3x"1" else
+                    x"00" & icache_hit_cnt  when cnt_addr_lo = 3x"2" else
+                    x"00" & icache_miss_cnt when cnt_addr_lo = 3x"3" else
+                    icache_miss_cycles      when cnt_addr_lo = 3x"4" else
+                    x"00" & ierat_hit_cnt   when cnt_addr_lo = 3x"5" else
+                    x"00" & ierat_miss_cnt  when cnt_addr_lo = 3x"6" else
+                    ierat_miss_cycles       when cnt_addr_lo = 3x"7" else
+                    48x"0";
+        cnt_dat3 <= x"00" & itlb_hit_cnt    when cnt_addr_lo = 3x"0" else
+                    x"00" & itlb_miss_cnt   when cnt_addr_lo = 3x"1" else
+                    x"00" & dcache_hit_cnt  when cnt_addr_lo = 3x"2" else
+                    x"00" & dcache_miss_cnt when cnt_addr_lo = 3x"3" else
+                    dcache_miss_cycles      when cnt_addr_lo = 3x"4" else
+                    x"00" & dtlb_hit_cnt    when cnt_addr_lo = 3x"5" else
+                    x"00" & dtlb_miss_cnt   when cnt_addr_lo = 3x"6" else
+                    48x"0";
+        cnt_data <= cnt_data_r0 when cnt_addr_hi = "000" else
+                    cnt_data_r1 when cnt_addr_hi = "001" else
+                    cnt_data_r2 when cnt_addr_hi = "010" else
+                    cnt_data_r3;
+
+        process(clk)
+        begin
+            if rising_edge(clk) then
+                if rst = '1' then
+                    tlbsrch_cnt <= 40x"0";
+                    tlbsrch_cyc_cnt <= 48x"0";
+                    tlbmiss_cnt <= 40x"0";
+                    tlbhit_cnt <= 40x"0";
+                    tlbhit_2M_cnt <= 40x"0";
+                    pagewalk_cnt <= 40x"0";
+                    pgwalk_cyc_cnt <= 48x"0";
+                    pwcsrch_cnt <= 40x"0";
+                    pwcsrch_cyc_cnt <= 48x"0";
+                    pwcmiss_cnt <= 40x"0";
+                    pwchit_2M_cnt <= 40x"0";
+                    pwchit_1G_cnt <= 40x"0";
+                    pwchit_512G_cnt <= 40x"0";
+                    pwc_evict_cnt <= 40x"0";
+                    tlb_evict_cnt <= 40x"0";
+                    mmu_dc_miss_cnt <= 40x"0";
+                    instr_cmp_cnt <= 40x"0";
+                    nonwait_cycles <= 48x"0";
+                    icache_hit_cnt <= 40x"0";
+                    icache_miss_cnt <= 40x"0";
+                    icache_miss_cycles <= 48x"0";
+                    ierat_hit_cnt <= 40x"0";
+                    ierat_miss_cnt <= 40x"0";
+                    ierat_miss_cycles <= 48x"0";
+                    itlb_hit_cnt <= 40x"0";
+                    itlb_miss_cnt <= 40x"0";
+                    dcache_hit_cnt <= 40x"0";
+                    dcache_miss_cnt <= 40x"0";
+                    dcache_miss_cycles <= 48x"0";
+                    dtlb_hit_cnt <= 40x"0";
+                    dtlb_miss_cnt <= 40x"0";
+                else
+                    if mmu_events.tlbsearch = '1' then
+                        tlbsrch_cnt <= tlbsrch_cnt + 1;
+                    end if;
+                    if mmu_events.tlbsrch_cycles = '1' then
+                        tlbsrch_cyc_cnt <= tlbsrch_cyc_cnt + 1;
+                    end if;
+                    if mmu_events.tlbmiss = '1' then
+                        tlbmiss_cnt <= tlbmiss_cnt + 1;
+                    end if;
+                    if mmu_events.tlbhit = '1' then
+                        tlbhit_cnt <= tlbhit_cnt + 1;
+                    end if;
+                    if mmu_events.tlbhit_2M = '1' then
+                        tlbhit_2M_cnt <= tlbhit_2M_cnt + 1;
+                    end if;
+                    if mmu_events.pagewalk = '1' then
+                        pagewalk_cnt <= pagewalk_cnt + 1;
+                    end if;
+                    if mmu_events.pgwalk_cycles = '1' then
+                        pgwalk_cyc_cnt <= pgwalk_cyc_cnt + 1;
+                    end if;
+                    if mmu_events.pwcsearch = '1' then
+                        pwcsrch_cnt <= pwcsrch_cnt + 1;
+                    end if;
+                    if mmu_events.pwcsrch_cycles = '1' then
+                        pwcsrch_cyc_cnt <= pwcsrch_cyc_cnt + 1;
+                    end if;
+                    if mmu_events.pwcmiss = '1' then
+                        pwcmiss_cnt <= pwcmiss_cnt + 1;
+                    end if;
+                    if mmu_events.pwchit_2M = '1' then
+                        pwchit_2M_cnt <= pwchit_2M_cnt + 1;
+                    end if;
+                    if mmu_events.pwchit_1G = '1' then
+                        pwchit_1G_cnt <= pwchit_1G_cnt + 1;
+                    end if;
+                    if mmu_events.pwchit_512G = '1' then
+                        pwchit_512G_cnt <= pwchit_512G_cnt + 1;
+                    end if;
+                    if mmu_events.pwc_evictions = '1' then
+                        pwc_evict_cnt <= pwc_evict_cnt + 1;
+                    end if;
+                    if mmu_events.tlb_evictions = '1' then
+                        tlb_evict_cnt <= tlb_evict_cnt + 1;
+                    end if;
+                    if mmu_events.pgwalk_miss = '1' then
+                        mmu_dc_miss_cnt <= mmu_dc_miss_cnt + 1;
+                    end if;
+                    if wback_events.instr_complete = '1' then
+                        instr_cmp_cnt <= instr_cmp_cnt + 1;
+                    end if;
+                    if ctrl.wait_state = '0' then
+                        nonwait_cycles <= nonwait_cycles + 1;
+                    end if;
+                    if icache_events.icache_hit = '1' then
+                        icache_hit_cnt <= icache_hit_cnt + 1;
+                    end if;
+                    if icache_events.icache_miss = '1' then
+                        icache_miss_cnt <= icache_miss_cnt + 1;
+                    end if;
+                    if icache_events.icache_miss_cycles = '1' then
+                        icache_miss_cycles <= icache_miss_cycles + 1;
+                    end if;
+                    if fetch_events.ierat_hit = '1' then
+                        ierat_hit_cnt <= ierat_hit_cnt + 1;
+                    end if;
+                    if fetch_events.ierat_miss = '1' then
+                        ierat_miss_cnt <= ierat_miss_cnt + 1;
+                    end if;
+                    if fetch_events.ierat_miss_cycles = '1' then
+                        ierat_miss_cycles <= ierat_miss_cycles + 1;
+                    end if;
+                    if fetch_events.itlb_hit = '1' then
+                        itlb_hit_cnt <= itlb_hit_cnt + 1;
+                    end if;
+                    if fetch_events.itlb_miss = '1' then
+                        itlb_miss_cnt <= itlb_miss_cnt + 1;
+                    end if;
+                    if dcache_events.load_hit = '1' then
+                        dcache_hit_cnt <= dcache_hit_cnt + 1;
+                    end if;
+                    if dcache_events.load_miss = '1' then
+                        dcache_miss_cnt <= dcache_miss_cnt + 1;
+                    end if;
+                    if dcache_events.load_miss_cycles = '1' then
+                        dcache_miss_cycles <= dcache_miss_cycles + 1;
+                    end if;
+                    if dcache_events.dtlb_hit = '1' then
+                        dtlb_hit_cnt <= dtlb_hit_cnt + 1;
+                    end if;
+                    if dcache_events.dtlb_miss = '1' then
+                        dtlb_miss_cnt <= dtlb_miss_cnt + 1;
+                    end if;
+                end if;
+                cnt_data_r0 <= cnt_dat0;
+                cnt_data_r1 <= cnt_dat1;
+                cnt_data_r2 <= cnt_dat2;
+                cnt_data_r3 <= cnt_dat3;
+            end if;
+        end process;
+    end generate;
 
     -- Logging RAM
     maybe_log: if LOG_LENGTH > 0 generate

--- a/dcache.vhdl
+++ b/dcache.vhdl
@@ -1188,6 +1188,7 @@ begin
         m_out.done <= r1.mmu_done;
         m_out.err <= r1.mmu_error;
         m_out.data <= r1.data_out;
+        m_out.miss <= r1.slow_valid;
 
 	-- We have a valid load or store hit or we just completed a slow
 	-- op such as a load miss, a NC load or a store
@@ -1413,10 +1414,12 @@ begin
         variable acks      : unsigned(2 downto 0);
     begin
         if rising_edge(clk) then
+            ev.load_hit <= req_is_hit;
             ev.dcache_refill <= '0';
             ev.load_miss <= '0';
             ev.store_miss <= '0';
             ev.dtlb_miss <= tlb_miss;
+            ev.dtlb_hit <= tlb_hit and r0.req.virt_mode;
             r1.choose_victim <= '0';
 
 	    -- On reset, clear all valid bits to force misses
@@ -1440,6 +1443,7 @@ begin
                 r1.prev_hit_ways <= (others => '0');
                 reservation.valid <= '0';
                 reservation.addr <= (others => '0');
+                ev.load_miss_cycles <= '0';
 
 		-- Not useful normally but helps avoiding tons of sim warnings
 		r1.wb.adr <= (others => '0');
@@ -1632,6 +1636,7 @@ begin
                             r1.reloading <= '1';
                             r1.write_tag <= '1';
                             ev.load_miss <= '1';
+                            ev.load_miss_cycles <= '1';
                         else
                             r1.state <= NC_LOAD_WAIT_ACK;
                         end if;
@@ -1710,6 +1715,7 @@ begin
                         r1.full <= '0';
                         r1.slow_valid <= '1';
                         r1.ls_valid <= '1';
+                        ev.load_miss_cycles <= '0';
                     end if;
 
 		    -- Incoming acks processing
@@ -1737,6 +1743,7 @@ begin
                             else
                                 r1.mmu_done <= '1';
                             end if;
+                            ev.load_miss_cycles <= '0';
                             -- NB: for lqarx, set the reservation on the first dword
                             if r1.req.reserve = '1' and r1.req.first_dw = '1' then
                                 reservation.valid <= '1';

--- a/execute1.vhdl
+++ b/execute1.vhdl
@@ -61,6 +61,7 @@ entity execute1 is
         ls_events    : in Loadstore1EventType;
         dc_events    : in DcacheEventType;
         ic_events    : in IcacheEventType;
+        f_events     : in FetchEventType;
 
         -- Access to SPRs from core_debug module
         dbg_spr_req   : in std_ulogic;
@@ -651,7 +652,7 @@ begin
                        dtlb_miss => dc_events.dtlb_miss,
                        dtlb_miss_resolved => dc_events.dtlb_miss_resolved,
                        icache_miss => ic_events.icache_miss,
-                       itlb_miss_resolved => ic_events.itlb_miss_resolved,
+                       itlb_miss_resolved => f_events.itlb_miss_resolved,
                        no_instr_avail => ex1.no_instr_avail,
                        dispatch => ex1.instr_dispatch,
                        ext_interrupt => ex2.ext_interrupt,

--- a/fetch1.vhdl
+++ b/fetch1.vhdl
@@ -34,6 +34,9 @@ entity fetch1 is
 	-- Request to icache
 	i_out         : out Fetch1ToIcacheType;
 
+        -- Events for performance analysis
+        events        : out FetchEventType;
+
         -- outputs to logger
         log_out       : out std_ulogic_vector(42 downto 0)
 	);
@@ -102,6 +105,8 @@ architecture behaviour of fetch1 is
     signal itlb_pte : tlb_pte_t;
     signal itlb_hit : std_ulogic;
 
+    signal ev : FetchEventType;
+
     -- Simple hash for direct-mapped TLB index
     function hash_ea(addr: std_ulogic_vector(63 downto 0)) return std_ulogic_vector is
         variable hash : std_ulogic_vector(TLB_BITS - 1 downto 0);
@@ -142,6 +147,11 @@ begin
             r.fetch_fail <= r_next.fetch_fail;
             r_int.tlbcheck <= r_next_int.tlbcheck;
             r_int.tlbstall <= r_next_int.tlbstall;
+            ev.ierat_miss <= r_next_int.tlbcheck;
+            ev.ierat_miss_cycles <= r_next_int.tlbcheck or r_next.fetch_fail;
+            ev.ierat_hit <= erat_hit;
+            ev.itlb_hit <= itlb_hit and r_int.tlbcheck;
+            ev.itlb_miss <= not itlb_hit and r_int.tlbcheck and not r.fetch_fail;
 	end if;
     end process;
     log_out <= log_nia;
@@ -277,7 +287,7 @@ begin
                 itlb_ptes(to_integer(unsigned(wr_index))) <= m_in.pte;
                 itlb_valids(to_integer(unsigned(wr_index))) <= '1';
             end if;
-            --ev.itlb_miss_resolved <= m_in.tlbld and not rst;
+            ev.itlb_miss_resolved <= m_in.tlbld and not rst;
         end if;
     end process;
 
@@ -437,6 +447,7 @@ begin
         i_out.next_nia <= next_nia;
         i_out.next_rpn <= v.rpn;
 
+        events <= ev;
     end process;
 
 end architecture behaviour;

--- a/fpga/top-acorn-cle-215.vhdl
+++ b/fpga/top-acorn-cle-215.vhdl
@@ -21,6 +21,7 @@ entity toplevel is
         SPI_FLASH_DEF_CKDV : natural := 1;
         SPI_FLASH_DEF_QUAD : boolean := true;
         LOG_LENGTH         : natural := 2048;
+        HAS_DMI_COUNTERS   : boolean := false;
         UART_IS_16550      : boolean := true
 	);
     port(
@@ -140,6 +141,7 @@ begin
             SPI_FLASH_DEF_CKDV => SPI_FLASH_DEF_CKDV,
             SPI_FLASH_DEF_QUAD => SPI_FLASH_DEF_QUAD,
             LOG_LENGTH         => LOG_LENGTH,
+            HAS_DMI_COUNTERS   => HAS_DMI_COUNTERS,
             UART0_IS_16550     => UART_IS_16550
 	    )
 	port map (

--- a/fpga/top-antmicro-artix-dc-scm.vhdl
+++ b/fpga/top-antmicro-artix-dc-scm.vhdl
@@ -24,6 +24,7 @@ entity toplevel is
         SPI_FLASH_DEF_CKDV : natural := 1;
         SPI_FLASH_DEF_QUAD : boolean := true;
         LOG_LENGTH         : natural := 512;
+        HAS_DMI_COUNTERS   : boolean := false;
         USE_LITEETH        : boolean  := true;
         UART_IS_16550      : boolean  := false;
         HAS_UART1          : boolean  := true;
@@ -187,6 +188,7 @@ begin
             SPI_FLASH_DEF_CKDV => SPI_FLASH_DEF_CKDV,
             SPI_FLASH_DEF_QUAD => SPI_FLASH_DEF_QUAD,
             LOG_LENGTH         => LOG_LENGTH,
+            HAS_DMI_COUNTERS   => HAS_DMI_COUNTERS,
             HAS_LITEETH        => USE_LITEETH,
             UART0_IS_16550     => UART_IS_16550,
             HAS_UART1          => HAS_UART1,

--- a/fpga/top-arty.vhdl
+++ b/fpga/top-arty.vhdl
@@ -25,6 +25,7 @@ entity toplevel is
         SPI_FLASH_DEF_CKDV : natural := 1;
         SPI_FLASH_DEF_QUAD : boolean := true;
         LOG_LENGTH         : natural := 512;
+        HAS_DMI_COUNTERS   : boolean := false;
         USE_LITEETH        : boolean  := false;
         UART_IS_16550      : boolean  := false;
         HAS_UART1          : boolean  := true;
@@ -313,6 +314,7 @@ begin
             SPI_FLASH_DEF_CKDV => SPI_FLASH_DEF_CKDV,
             SPI_FLASH_DEF_QUAD => SPI_FLASH_DEF_QUAD,
             LOG_LENGTH         => LOG_LENGTH,
+            HAS_DMI_COUNTERS   => HAS_DMI_COUNTERS,
             HAS_LITEETH        => USE_LITEETH,
             UART0_IS_16550     => UART_IS_16550,
             HAS_UART1          => HAS_UART1,

--- a/fpga/top-generic.vhdl
+++ b/fpga/top-generic.vhdl
@@ -15,6 +15,7 @@ entity toplevel is
         HAS_BTC       : boolean  := false;
         ICACHE_NUM_LINES : natural := 64;
         LOG_LENGTH    : natural := 512;
+        HAS_DMI_COUNTERS : boolean := false;
 	DISABLE_FLATTEN_CORE : boolean := false;
         UART_IS_16550 : boolean  := true
 	);
@@ -76,6 +77,7 @@ begin
             HAS_BTC       => HAS_BTC,
 	    ICACHE_NUM_LINES => ICACHE_NUM_LINES,
             LOG_LENGTH    => LOG_LENGTH,
+            HAS_DMI_COUNTERS => HAS_DMI_COUNTERS,
 	    DISABLE_FLATTEN_CORE => DISABLE_FLATTEN_CORE,
             UART0_IS_16550     => UART_IS_16550
 	    )

--- a/fpga/top-genesys2.vhdl
+++ b/fpga/top-genesys2.vhdl
@@ -21,6 +21,7 @@ entity toplevel is
         SPI_FLASH_DEF_CKDV : natural := 1;
         SPI_FLASH_DEF_QUAD : boolean := true;
         LOG_LENGTH         : natural := 2048;
+        HAS_DMI_COUNTERS   : boolean := false;
         USE_LITEETH        : boolean := true;
         UART_IS_16550      : boolean := true
 	);
@@ -158,6 +159,7 @@ begin
             SPI_FLASH_DEF_CKDV => SPI_FLASH_DEF_CKDV,
             SPI_FLASH_DEF_QUAD => SPI_FLASH_DEF_QUAD,
             LOG_LENGTH         => LOG_LENGTH,
+            HAS_DMI_COUNTERS   => HAS_DMI_COUNTERS,
             UART0_IS_16550     => UART_IS_16550,
             HAS_LITEETH        => USE_LITEETH
 	    )

--- a/fpga/top-nexys-video.vhdl
+++ b/fpga/top-nexys-video.vhdl
@@ -23,6 +23,7 @@ entity toplevel is
         SPI_FLASH_DEF_CKDV : natural := 1;
         SPI_FLASH_DEF_QUAD : boolean := true;
         LOG_LENGTH         : natural := 2048;
+        HAS_DMI_COUNTERS   : boolean := false;
         UART_IS_16550      : boolean := true;
         USE_LITEETH        : boolean := false;
         USE_LITESDCARD     : boolean := false
@@ -181,6 +182,7 @@ begin
             SPI_FLASH_DEF_CKDV => SPI_FLASH_DEF_CKDV,
             SPI_FLASH_DEF_QUAD => SPI_FLASH_DEF_QUAD,
             LOG_LENGTH         => LOG_LENGTH,
+            HAS_DMI_COUNTERS   => HAS_DMI_COUNTERS,
             UART0_IS_16550     => UART_IS_16550,
             HAS_LITEETH        => USE_LITEETH,
             HAS_SD_CARD        => USE_LITESDCARD

--- a/fpga/top-wukong-v2.vhdl
+++ b/fpga/top-wukong-v2.vhdl
@@ -23,6 +23,7 @@ entity toplevel is
         SPI_FLASH_DEF_CKDV : natural := 1;
         SPI_FLASH_DEF_QUAD : boolean := true;
         LOG_LENGTH         : natural := 512;
+        HAS_DMI_COUNTERS   : boolean := false;
         USE_LITEETH        : boolean  := false;
         UART_IS_16550      : boolean  := true;
         HAS_UART1          : boolean  := false;
@@ -181,6 +182,7 @@ begin
             SPI_FLASH_DEF_CKDV => SPI_FLASH_DEF_CKDV,
             SPI_FLASH_DEF_QUAD => SPI_FLASH_DEF_QUAD,
             LOG_LENGTH         => LOG_LENGTH,
+            HAS_DMI_COUNTERS   => HAS_DMI_COUNTERS,
             HAS_LITEETH        => USE_LITEETH,
             UART0_IS_16550     => UART_IS_16550,
             HAS_UART1          => HAS_UART1,

--- a/icache.vhdl
+++ b/icache.vhdl
@@ -650,7 +650,8 @@ begin
     begin
         if rising_edge(clk) then
             ev.icache_miss <= '0';
-            ev.itlb_miss_resolved <= '0';
+            ev.icache_miss_cycles <= req_is_miss;
+            ev.icache_hit <= req_is_hit and not stall_in;
             r.recv_valid <= '0';
 	    -- On reset, clear all valid bits to force misses
             if rst = '1' then

--- a/microwatt.core
+++ b/microwatt.core
@@ -155,6 +155,7 @@ targets:
       - clk_frequency
       - disable_flatten_core
       - log_length=2048
+      - has_dmi_counters
       - uart_is_16550
       - has_fpu
       - has_btc
@@ -174,6 +175,7 @@ targets:
       - disable_flatten_core
       - spi_flash_offset=10485760
       - log_length=2048
+      - has_dmi_counters
       - uart_is_16550
     tools:
       vivado: {part : xc7a200tsbg484-2}
@@ -191,6 +193,7 @@ targets:
       - disable_flatten_core
       - spi_flash_offset=12582912
       - log_length=2048
+      - has_dmi_counters
       - uart_is_16550
     generate: [git_hash]
     tools:
@@ -209,6 +212,7 @@ targets:
       - no_bram
       - spi_flash_offset=10485760
       - log_length=2048
+      - has_dmi_counters
       - uart_is_16550
       - has_fpu
       - has_btc
@@ -229,6 +233,7 @@ targets:
       - no_bram
       - spi_flash_offset=12582912
       - log_length=2048
+      - has_dmi_counters
       - uart_is_16550
     generate: [litedram_genesys2, liteeth_genesys2, git_hash]
     tools:
@@ -246,6 +251,7 @@ targets:
       - disable_flatten_core
       - spi_flash_offset=10485760
       - log_length=2048
+      - has_dmi_counters
       - uart_is_16550
       - has_fpu
       - has_btc
@@ -267,6 +273,7 @@ targets:
       - no_bram
       - spi_flash_offset=10485760
       - log_length=2048
+      - has_dmi_counters
       - uart_is_16550
       - has_fpu
       - has_btc
@@ -286,6 +293,7 @@ targets:
       - disable_flatten_core
       - spi_flash_offset=3145728
       - log_length=512
+      - has_dmi_counters
       - uart_is_16550
       - has_uart1
       - has_fpu=false
@@ -309,6 +317,7 @@ targets:
       - no_bram
       - spi_flash_offset=3145728
       - log_length=512
+      - has_dmi_counters
       - uart_is_16550
       - has_uart1
       - has_fpu=false
@@ -329,6 +338,7 @@ targets:
       - disable_flatten_core
       - spi_flash_offset=4194304
       - log_length=2048
+      - has_dmi_counters
       - uart_is_16550
       - has_uart1
       - has_fpu
@@ -354,6 +364,7 @@ targets:
       - no_bram
       - spi_flash_offset=4194304
       - log_length=2048
+      - has_dmi_counters
       - uart_is_16550
       - has_uart1
       - has_fpu
@@ -376,6 +387,7 @@ targets:
       - disable_flatten_core
       - no_bram
       - log_length=2048
+      - has_dmi_counters
       - uart_is_16550
       - has_uart1
       - has_fpu
@@ -398,6 +410,7 @@ targets:
       - spi_flash_offset=4194304
       - clk_frequency=100000000
       - log_length=2048
+      - has_dmi_counters
       - uart_is_16550
       - has_fpu
       - has_btc
@@ -419,6 +432,7 @@ targets:
       - no_bram=true
       - spi_flash_offset=4194304
       - log_length=0
+      - has_dmi_counters
       - uart_is_16550
       - has_fpu
       - has_btc
@@ -438,6 +452,7 @@ targets:
       - clk_frequency
       - disable_flatten_core
       - log_length=512
+      - has_dmi_counters
       - uart_is_16550
       - has_fpu=false
       - has_btc=false
@@ -613,3 +628,9 @@ parameters:
     datatype    : int
     description : Length of the core log buffer in entries (32 bytes each)
     paramtype   : generic
+
+  has_dmi_counters:
+    datatype    : bool
+    description : Include DMI-accessible performance counters
+    paramtype   : generic
+    default     : false

--- a/mmu.vhdl
+++ b/mmu.vhdl
@@ -20,7 +20,9 @@ entity mmu is
         d_out : out MmuToDcacheType;
         d_in  : in DcacheToMmuType;
 
-        i_out : out MmuToITLBType
+        i_out : out MmuToITLBType;
+
+        ev    : out MMUEventType
         );
 end mmu;
 
@@ -135,10 +137,12 @@ architecture behave of mmu is
         miss        : std_ulogic;
         hit_way     : std_ulogic_vector(1 downto 0);
         repl_way    : std_ulogic_vector(1 downto 0);
+        eviction    : std_ulogic;
         update_plru : std_ulogic;
         tlbie_done  : std_ulogic;
         inval_all   : std_ulogic;
         wr_hash     : std_ulogic_vector(TLB_HASH_BITS - 1 downto 0);
+        searching   : std_ulogic;
     end record;
     constant mmu_tlb_reg_init : mmu_tlb_reg_t := (
         state   => IDLE, addr => 40x"0", pid => 12x"0",
@@ -229,6 +233,10 @@ architecture behave of mmu is
         repl_way_2M  : std_ulogic_vector(1 downto 0);
         repl_way_1G  : std_ulogic_vector(1 downto 0);
         repl_way_HT  : std_ulogic_vector(1 downto 0);
+        eviction_2M  : std_ulogic;
+        eviction_1G  : std_ulogic;
+        eviction_HT  : std_ulogic;
+        eviction     : std_ulogic;
         wr_leaf      : std_ulogic;
         wr_level     : std_ulogic_vector(1 downto 0);
         update_plru  : std_ulogic;
@@ -238,6 +246,7 @@ architecture behave of mmu is
         inval_pid    : std_ulogic;
         rd_hash      : std_ulogic_vector(PWC_HASH_BITS - 1 downto 0);
         reg_hash     : std_ulogic_vector(PWC_HASH_BITS - 1 downto 0);
+        searching    : std_ulogic;
     end record;
 
     constant mmu_pwc_reg_init : mmu_pwc_reg_t := (
@@ -410,6 +419,10 @@ begin
         is_hit := '0';
         idx := "000";
         tv.update_plru := '0';
+        ev.tlbsearch <= '0';
+        ev.tlbmiss <= '0';
+        ev.tlbhit <= '0';
+        ev.tlb_evictions <= '0';
         case tr.state is
             when IDLE =>
                 tv.addr := l_in.addr(51 downto 12);
@@ -462,10 +475,12 @@ begin
                 idx := "001";
                 tlb_doread <= '1';
                 tlb_rdren <= '1';
+                ev.tlbsearch <= '1';
                 if tr.bad_ea = '0' then
                     tv.state := SEARCH2;
                 else
                     tv.miss := '1';
+                    ev.tlbmiss <= '1';
                     tv.tlbie_done := tr.is_tlbie;
                     tv.state := IDLE;
                 end if;
@@ -484,13 +499,16 @@ begin
                 -- work out which way to replace in case of a miss
                 if valids = "1111" then
                     tv.repl_way := tlb_plru_victim;
+                    tv.eviction := '1';
                 else
                     tv.repl_way := find_first_one(not valids);
+                    tv.eviction := '0';
                 end if;
                 -- next read word 2 of group
                 idx := "010";
                 if tv.may_hit = "0000" then
                     tv.miss := '1';
+                    ev.tlbmiss <= '1';
                     if tr.is_tlbie = '0' then
                         tv.state := WAITW;
                     else
@@ -527,6 +545,7 @@ begin
                     tlb_doread <= '1';
                 elsif tv.may_hit = "0000" then
                     tv.miss := '1';
+                    ev.tlbmiss <= '1';
                     tv.state := WAITW;
                 else
                     tlb_rdren <= '1';
@@ -548,6 +567,7 @@ begin
                     tv.state := IDLE;
                 elsif tv.may_hit = "0000" then
                     tv.miss := '1';
+                    ev.tlbmiss <= '1';
                     tv.state := WAITW;
                 else
                     tv.hit_way := '1' & not tv.may_hit(2);
@@ -559,6 +579,7 @@ begin
                 tv.repl_way := tr.hit_way;
                 tlb_rdren <= '1';
                 tv.hit := '1';
+                ev.tlbhit <= '1';
                 tv.update_plru := '1';
                 tv.state := WAITW;
             when WAITW =>
@@ -582,6 +603,7 @@ begin
                 end if;
                 idx := '0' & tr.repl_way(1) & not tr.repl_way(1);
                 tv.state := WRPTE2;
+                ev.tlb_evictions <= tr.eviction;
             when WRPTE2 =>
                 tlb_wrdata <= r.pde;
                 tlb_wren <= "1111";
@@ -615,9 +637,15 @@ begin
                     tv.state := IDLE;
                 end if;
         end case;
+        tv.searching := '0';
+        if tv.state = SEARCH1 or tv.state = SEARCH2 or tv.state = SEARCH3 or
+            tv.state = SEARCH4 or tv.state = RDPTE then
+            tv.searching := '1';
+        end if;
         tlb_rdaddr <= tv.hash_4k & idx;
         tlb_wraddr <= tr.wr_hash & idx;
         trin <= tv;
+        ev.tlbsrch_cycles <= tr.searching;
     end process;
 
     -- Synchronous reads and writes to PWC array
@@ -689,6 +717,7 @@ begin
         variable idx : std_ulogic_vector(2 downto 0);
         variable wdat : std_ulogic_vector(15 downto 0);
         variable rway : std_ulogic_vector(1 downto 0);
+        variable evict : std_ulogic;
         variable wr_hash : std_ulogic_vector(5 downto 0);
     begin
         pv := pr;
@@ -700,6 +729,8 @@ begin
         idx := "000";
         wr_hash := (others => '0');
         pv.update_plru := '0';
+        ev.pwcsearch <= '0';
+        ev.pwc_evictions <= '0';
         case pr.state is
             when IDLE =>
                 pv.state := IDLE;
@@ -723,6 +754,10 @@ begin
                 pv.missed_2M := '0';
                 pv.missed_1G := '0';
                 pv.missed_512G := '0';
+                pv.eviction := '0';
+                pv.eviction_2M := '0';
+                pv.eviction_1G := '0';
+                pv.eviction_HT := '0';
                 if l_in.valid = '1' then
                     pv.hit := '0';
                     pv.miss := '0';
@@ -756,6 +791,7 @@ begin
                             if ap = "001" then                  -- 2MB page
                                 pwc_doread <= '1';
                                 pv.state := INVAL_2M;
+                                pv.searching := '1';
                             else
                                 -- 4k, 64k, 1G or unrecognized
                                 pv.tlbie_done := '1';
@@ -766,6 +802,7 @@ begin
                         pwc_doread <= '1';
                         pv.state := SEARCH1;
                         pv.next_state := SEARCH_2M_0;
+                        pv.searching := '1';
                     end if;
                 end if;
 
@@ -774,10 +811,12 @@ begin
                 pv.rd_hash := pr.hash_1G;
                 pwc_doread <= '1';
                 pwc_rdren <= '1';
+                ev.pwcsearch <= '1';
                 if pr.bad_ea = '0' then
                     pv.state := SEARCH_2M_0;
                 else
                     pv.miss := '1';
+                    pv.searching := '0';
                     pv.state := IDLE;
                 end if;
 
@@ -793,8 +832,10 @@ begin
                         pv.may_hit_2M(i) := '1';
                     end if;
                 end loop;
+                pv.eviction_2M := '0';
                 if valids = "1111" then
                     pv.repl_way_2M := pwc_plru_victim;
+                    pv.eviction_2M := '1';
                 else
                     pv.repl_way_2M := find_first_one(not valids);
                 end if;
@@ -874,8 +915,10 @@ begin
                         pv.may_hit_1G(i) := '1';
                     end if;
                 end loop;
+                pv.eviction_1G := '0';
                 if valids = "1111" then
                     pv.repl_way_1G := pwc_plru_victim;
+                    pv.eviction_1G := '1';
                 else
                     pv.repl_way_1G := find_first_one(not valids);
                 end if;
@@ -922,6 +965,7 @@ begin
                         pwc_rdren <= '1';
                     else
                         pv.miss := '1';
+                        pv.searching := '0';
                         pv.state := WAITW;
                     end if;
                 end if;
@@ -938,8 +982,10 @@ begin
                         pv.may_hit_512G(i) := '1';
                     end if;
                 end loop;
+                pv.eviction_HT := '0';
                 if valids = "1111" then
                     pv.repl_way_HT := pwc_plru_victim;
+                    pv.eviction_HT := '1';
                 else
                     pv.repl_way_HT := find_first_one(not valids);
                 end if;
@@ -954,6 +1000,7 @@ begin
                 end if;
                 if pv.missed_512G = '1' and pr.missed_1G = '1' then
                     pv.miss := '1';
+                    pv.searching := '0';
                     pv.state := WAITW;
                 else
                     pv.state := pr.next_state;
@@ -976,12 +1023,14 @@ begin
                     pwc_doread <= '1';
                 else
                     pv.miss := '1';
+                    pv.searching := '0';
                     pv.state := WAITW;
                 end if;
 
             when RDPDE =>
                 pwc_rdren <= '1';
                 pv.hit := '1';
+                pv.searching := '0';
                 pv.update_plru := '1';
                 pv.state := WAITW;
             when WAITW =>
@@ -989,21 +1038,26 @@ begin
                 pv.wr_leaf := r.pde(62);
                 pv.wr_level := r.pwc_level;
                 rway := "00";
+                evict := '0';
                 if r.rereadpte = '1' then
                     -- rewriting a 2M PTE with changed permissions
                     rway := pr.sel_way;
+                    evict := '0';
                     wr_hash := pr.hash_2M;
                 else
                     -- choose way according to which group is to be written
                     case r.pwc_level is
                         when "00" =>        -- 2M
                             rway := pr.repl_way_2M;
+                            evict := pr.eviction_2M;
                             wr_hash := pr.hash_2M;
                         when "01" =>
                             rway := pr.repl_way_1G;
+                            evict := pr.eviction_2M;
                             wr_hash := pr.hash_1G;
                         when others =>
                             rway := pr.repl_way_HT;
+                            evict := pr.eviction_2M;
                             wr_hash := pr.hash_512G;
                     end case;
                 end if;
@@ -1013,6 +1067,7 @@ begin
                     idx := '1' & rway;
                     pv.rd_hash := wr_hash;
                     pv.sel_way := rway;
+                    pv.eviction := evict;
                     pv.update_plru := '1';
                     if r.pwc_level = "00" then
                         pv.state := WRPTE1_2M;
@@ -1046,6 +1101,7 @@ begin
                 -- write one 16b section of word 0
                 wr_hash := pr.rd_hash;
                 pwc_wren(to_integer(unsigned(pr.sel_way))) <= '1';
+                ev.pwc_evictions <= pr.eviction;
                 if pr.wr_leaf = '1' then
                     pv.state := IDLE;
                 else
@@ -1120,6 +1176,7 @@ begin
                 wr_hash := pr.hash_2M;
                 pwc_wren <= pv.may_hit_2M;
                 pv.tlbie_done := '1';
+                pv.searching := '0';
                 pv.state := IDLE;
 
         end case;
@@ -1132,6 +1189,7 @@ begin
         pwc_rdaddr <= pv.rd_hash & idx;
         pwc_wraddr <= wr_hash & idx;
         prin <= pv;
+        ev.pwcsrch_cycles <= pr.searching;
     end process;
 
     -- Multiplex internal SPR values back to loadstore1, selected
@@ -1270,6 +1328,7 @@ begin
         variable rc_ok : std_ulogic;
         variable addr : std_ulogic_vector(63 downto 0);
         variable data : std_ulogic_vector(63 downto 0);
+        variable walking : std_ulogic;
         variable tlbdone, pwcdone : std_ulogic;
     begin
         v := r;
@@ -1288,6 +1347,12 @@ begin
         v.inval_all := '0';
         ptbl_rd := '0';
         prtbl_rd := '0';
+        ev.pagewalk <= '0';
+        ev.pwcmiss <= '0';
+        ev.pwchit_2M <= '0';
+        ev.pwchit_1G <= '0';
+        ev.pwchit_512G <= '0';
+        ev.tlbhit_2M <= '0';
 
         -- Radix tree data structures in memory are big-endian,
         -- so we need to byte-swap them
@@ -1391,6 +1456,7 @@ begin
                 end if;
             elsif pr.hit = '1' and pr.hit_size = "00" and pwc_rdreg(62) = '1' and r.rereadpte = '0' then
                 v.pde := pwc_rdreg;
+                ev.tlbhit_2M <= '1';
                 if check_perm_c(pwc_rdreg, r.priv, r.iside, r.store, pwc_rdreg(7)) = '1' then
                     -- Large-page (2M) PTE from PWC is in pwc_rdreg
                     v.shift := to_unsigned(9, 6);
@@ -1406,8 +1472,18 @@ begin
                 v.shift := unsigned(six);
                 v.mask_size := to_unsigned(9, 5);
                 v.pgbase := pwc_rdreg(55 downto 8) & x"00";
+                ev.pagewalk <= '1';
+                if pr.hit_size = "00" then
+                    ev.pwchit_2M <= '1';
+                elsif pr.hit_size = "01" then
+                    ev.pwchit_1G <= '1';
+                else
+                    ev.pwchit_512G <= '1';
+                end if;
                 v.state := RADIX_LOOKUP;
             elsif tlbdone = '1' and pwcdone = '1' then
+                ev.pagewalk <= '1';
+                ev.pwcmiss <= '1';
                 if pt_valid = '0' then
                     -- need to fetch process table entry
                     -- set v.shift so we can use finalmask for generating
@@ -1584,6 +1660,13 @@ begin
             addr := pgtable_addr;
             tlb_data := (others => '0');
         end if;
+
+        walking := '0';
+        if r.state = RADIX_LOOKUP or r.state = RADIX_READ_WAIT then
+            walking := '1';
+        end if;
+        ev.pgwalk_cycles <= walking;
+        ev.pgwalk_miss <= d_in.done and d_in.miss;
 
         l_out.done <= r.done;
         l_out.err <= r.err;

--- a/scripts/mw_debug/mw_debug.c
+++ b/scripts/mw_debug/mw_debug.c
@@ -48,6 +48,8 @@ unsigned int core;
 #define DBG_LOG_DATA		(0x17 + (core << 4))
 #define DBG_LOG_TRIGGER		(0x18 + (core << 4))
 #define DBG_LOG_MTRIGGER	(0x19 + (core << 4))
+#define DBG_LOG_CNT_ADDR	(0x1c + (core << 4))
+#define DBG_LOG_CNT_DATA	(0x1d + (core << 4))
 
 static bool debug;
 
@@ -792,6 +794,59 @@ static void mtrig_set(uint64_t addr)
 	check(dmi_write(DBG_LOG_MTRIGGER, (addr & ~(uint64_t)2) | 1), "writing LOG_MTRIGGER");
 }
 
+static const char *cnt_names[] = {
+	"TLB searches",
+	"TLB search cycles",
+	"TLB misses",
+	"TLB hits 4k",
+	"TLB hits 2M",
+	"page walks",
+	"page walk cycles",
+	"PWC searches",
+	"PWC search cycles",
+	"PWC misses",
+	"PWC hits 2M",
+	"PWC hits 1G",
+	"PWC hits 512G",
+	"PWC evictions",
+	"TLB evictions",
+	"MMU dcache misses",
+
+	"instrs completed",
+	"non-wait cycles",
+	"icache hits",
+	"icache misses",
+	"icache miss cycles",
+	"ierat hits",
+	"ierat misses",
+	"ierat miss cycles",
+	"itlb hits",
+	"itlb misses",
+	"dcache load hits",
+	"dcache load misses",
+	"dcache load cycles",
+	"dtlb hits",
+	"dtlb misses",
+};
+
+static void cnt_read(uint64_t reg, uint64_t count)
+{
+	uint64_t data;
+
+	reg &= 0x3f;
+	if (reg + count > 64)
+		count = 64 - reg;
+	for (; count != 0; --count, ++reg) {
+		check(dmi_write(DBG_LOG_CNT_ADDR, reg), "setting counter index");
+		check(dmi_read(DBG_LOG_CNT_DATA, &data), "reading counter data");
+		if (reg < sizeof(cnt_names) / sizeof(cnt_names[0]))
+			printf("%20s", cnt_names[reg]);
+		else
+			printf("%" PRId64, reg);
+		printf(": %14" PRId64 "\n", data);
+	}
+}
+
 static void usage(const char *cmd)
 {
 	fprintf(stderr, "Usage: %s -b <jtag|ecp5|sim> [-c core#] <command> <args>\n", cmd);
@@ -827,6 +882,10 @@ static void usage(const char *cmd)
 	fprintf(stderr, "  mtrig 			show logging stop trigger status\n");
 	fprintf(stderr, "  mtrig off 			clear logging stop trigger address\n");
 	fprintf(stderr, "  mtrig <addr>			set logging stop trigger address\n");
+
+	fprintf(stderr, "\n");
+	fprintf(stderr, " Core counter display:\n");
+	fprintf(stderr, "  cnt <counter-num> [# counters]\n");
 
 	fprintf(stderr, "\n");
 	fprintf(stderr, " JTAG:\n");
@@ -1015,6 +1074,15 @@ int main(int argc, char *argv[])
 				addr = strtoul(argv[i], NULL, 16);
 				mtrig_set(addr);
 			}
+		} else if (strcmp(argv[i], "cnt") == 0) {
+			uint64_t c, n = 1;
+
+			if (i + 1 >= argc)
+				usage(argv[0]);
+			c = strtoul(argv[++i], NULL, 10);
+			if (i+1 < argc && isdigit(argv[i+1][0]))
+				n = strtoul(argv[++i], NULL, 10);
+			cnt_read(c, n);
 		} else {
 			fprintf(stderr, "Unknown command %s\n", argv[i]);
 			usage(argv[0]);

--- a/soc.vhdl
+++ b/soc.vhdl
@@ -84,6 +84,7 @@ entity soc is
         SPI_FLASH_DEF_QUAD : boolean := false;
         SPI_BOOT_CLOCKS    : boolean := true;
         LOG_LENGTH         : natural := 512;
+        HAS_DMI_COUNTERS   : boolean := false;
         HAS_LITEETH        : boolean := false;
 	UART0_IS_16550     : boolean := true;
 	HAS_UART1          : boolean := false;
@@ -377,6 +378,7 @@ begin
 	    DISABLE_FLATTEN => DISABLE_FLATTEN_CORE,
 	    ALT_RESET_ADDRESS => ALT_RESET_ADDRESS,
             LOG_LENGTH => LOG_LENGTH,
+            HAS_DMI_COUNTERS => HAS_DMI_COUNTERS,
             ICACHE_NUM_LINES => ICACHE_NUM_LINES,
             ICACHE_NUM_WAYS => ICACHE_NUM_WAYS,
             ICACHE_TLB_SIZE => ICACHE_TLB_SIZE,


### PR DESCRIPTION
This adds a collection of counters for a set of performance-related events in the core, primarily in the MMU, D-cache and I-cache.  These counters are accessible via the DMI debug interface and can be printed using the mw_debug program.  This infrastructure is optional and can be enabled for FPGA targets using the --use_dmi_counters argument to fusesoc.

Currently there are 31 counters implemented.  Counters that count occurrences of events such as dcache load misses are 40 bits wide. Counters that count a number of cycles, such as the total time taken in handling dcache load misses, are 48 bits wide.